### PR TITLE
Add jemalloc & tcmalloc support

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -14,6 +14,13 @@ run_test_suite() {
 
     # sanity check the file type
     file target/$TARGET/debug/rbspy
+
+    sudo apt-get install -y libjemalloc1
+    sudo apt-get install -y libtcmalloc-minimal4
+
+    # test jemalloc + tcmalloc
+    target/$TARGET/debug/rbspy record env LD_PRELOAD=/usr/lib/libjemalloc.so.1 /usr/bin/ruby ci/ruby-programs/short_program.rb
+    target/$TARGET/debug/rbspy record env LD_PRELOAD=/usr/lib/libtcmalloc_minimal.so.4 /usr/bin/ruby ci/ruby-programs/short_program.rb
 }
 
 run_docker_tests() {

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -167,7 +167,7 @@ fn test_current_thread_address() {
 
 fn is_maybe_thread_function<T: 'static>(
     version: &str,
-) -> Box<Fn(usize, &T, &MapRange, &Vec<MapRange>) -> bool>
+) -> Box<Fn(usize, &T, &Vec<MapRange>) -> bool>
 where
     T: CopyAddress,
 {

--- a/src/ruby_version.rs
+++ b/src/ruby_version.rs
@@ -159,8 +159,8 @@ macro_rules! get_stack_trace(
 
 use proc_maps::{maps_contain_addr, MapRange};
 
-pub fn is_maybe_thread<T>(x: usize, source: &T, heap_map: &MapRange, all_maps: &Vec<MapRange>) -> bool where T: CopyAddress{
-    if !heap_map.contains_addr(x) {
+pub fn is_maybe_thread<T>(x: usize, source: &T, all_maps: &Vec<MapRange>) -> bool where T: CopyAddress{
+    if !maps_contain_addr(x, all_maps) {
         return false;
     }
 


### PR DESCRIPTION
Previously we looked up the heap's memory map in `/proc/$PID/maps` and used that as a way to sanity check addresses that should be on the heap. It turns out that this doesn't work with jemalloc and tcmalloc, so this PR just removes the code that looks up the heap's memory map and instead just checks that the addresses we're sanity checking are *somewhere* in the process's memory maps.

This also adds two small tests that LD_PRELOAD jemalloc/tcmalloc to make sure that the profiler actually works with those two mallocs.