### PR TITLE
Only print debug output when there are errors

### DIFF
--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -117,9 +117,7 @@ fn get_ruby_version_retry(pid: pid_t) -> Result<String, Error> {
 
 pub fn get_ruby_version(pid: pid_t) -> Result<String, Error> {
     let addr = address_finder::get_ruby_version_address(pid)?;
-    debug!("ruby version addr: {:x}", addr);
     let x: [c_char; 15] = copy_struct(addr, &pid.try_into_process_handle().unwrap())?;
-    debug!("ruby version struct: {:?}", x);
     Ok(unsafe {
         std::ffi::CStr::from_ptr(x.as_ptr() as *mut c_char)
             .to_str()?


### PR DESCRIPTION
This makes the debugging output more organized/useful -- the main time I think debugging output will be useful is when there's an error getting a stack trace. So this moves most of the debug printing to the case where there's actually an error.

This should make it easier to ask users "hey, if you run into an error, rerun it with `env RUST_LOG=debug` and send us the output of that"

This prints out the cfp, iseq, and thread structs, as well as the rstring struct, which I'm hoping will be a good start.