### PR TITLE
Add support for profiling processes in Linux containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ dependencies = [
  "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruby-bindings 0.1.0",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -513,6 +514,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
@@ -764,6 +770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum skeptic 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "061203a849117b0f7090baf8157aa91dac30545208fbb85166ac58b4ca33d89c"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ failure = "0.1.1"
 failure_derive = "0.1.1"
 ruby-bindings = { path = "ruby-bindings" }
 
+[target.'cfg(target_os="linux")'.dependencies]
+scopeguard = "0.3.3"
+
 [target.'cfg(target_os="macos")'.dependencies]
 mach = "0.0.5"
 regex = "0.2.3"

--- a/src/address_finder.rs
+++ b/src/address_finder.rs
@@ -71,10 +71,15 @@ mod os_impl {
     use elf;
     use proc_maps::*;
     use failure::Error;
+    use failure::ResultExt;
     use libc::pid_t;
+    use libc;
     use std;
+    use std::fs;
+    use std::os::linux::fs::MetadataExt;
     use address_finder::AddressFinderError;
     use read_process_memory::*;
+    use std::os::unix::prelude::*;
 
     pub fn current_thread_address(
         pid: pid_t,
@@ -116,6 +121,50 @@ mod os_impl {
                 ).ok_or(format_err!("Couldn't find ruby version."))
             }
         }
+    }
+
+    fn switch_ns<F: AsRawFd>(f: &F) -> Result<(), Error> {
+        let fd = f.as_raw_fd();
+        let result = unsafe { libc::setns(fd, libc::CLONE_NEWNS) };
+        match result {
+            0 => Ok(()),
+            _ => Ok(Err(std::io::Error::last_os_error()).context(format!("Couldn't switch to mount namespace"))?),
+        }
+    }
+
+    fn proc_maps(pid: pid_t) -> Result<Vec<MapRange>, AddressFinderError> {
+        get_proc_maps(pid).map_err(|x| match x.kind() {
+            std::io::ErrorKind::NotFound => AddressFinderError::NoSuchProcess(pid),
+            std::io::ErrorKind::PermissionDenied => AddressFinderError::PermissionDenied(pid),
+            _ => AddressFinderError::ProcMapsError(pid),
+        })
+    }
+
+    fn get_program_info(pid: pid_t) -> Result<ProgramInfo, Error> {
+        // Check if the two processes are in the same mount namespace.
+        // If not, switch mount namespaces before running `get_program_info`
+        // We need to do this because the binaries we need to look at to find the symbols might be
+        // in a different mount namespace (like /usr/bin/ruby1.9.1 for instance) and if they are we
+        // have to switch mount namespaces to access them
+        let other_proc_mnt = &format!("/proc/{}/ns/mnt", pid);
+        let self_proc_mnt = "/proc/self/ns/mnt";
+        // We need to get `/proc/$PID/maps` before switching namespaces
+        let all_maps = proc_maps(pid)?;
+        // read the inode number to check if the two mount namespaces are the same
+        if fs::metadata(other_proc_mnt)?.st_ino() == fs::metadata(self_proc_mnt)?.st_ino() {
+            get_program_info_inner(pid, all_maps)
+        } else {
+            // switch mount namespace and then switch back after getting the program info
+            // We need to save the fd of the current mount namespace so we can switch back
+            let new_ns = fs::File::open(other_proc_mnt)?;
+            let old_ns = fs::File::open(self_proc_mnt)?;
+            switch_ns(&new_ns)?;
+            // if there's an error at any point, always switch back to the old namespace
+            defer!({switch_ns(&old_ns);});
+            let proginfo = get_program_info_inner(pid, all_maps);
+            proginfo
+        }
+        
     }
 
     fn elf_symbol_value(elf_file: &elf::File, symbol_name: &str) -> Option<usize> {
@@ -238,12 +287,7 @@ mod os_impl {
         pub libruby_elf: Option<elf::File>,
     }
 
-    pub fn get_program_info(pid: pid_t) -> Result<ProgramInfo, Error> {
-        let all_maps = get_proc_maps(pid).map_err(|x| match x.kind() {
-            std::io::ErrorKind::NotFound => AddressFinderError::NoSuchProcess(pid),
-            std::io::ErrorKind::PermissionDenied => AddressFinderError::PermissionDenied(pid),
-            _ => AddressFinderError::ProcMapsError(pid),
-        })?;
+    pub fn get_program_info_inner(pid: pid_t, all_maps: Vec<MapRange>) -> Result<ProgramInfo, Error> {
         let ruby_map = Box::new(get_map(&all_maps, "bin/ruby", "r-xp")
             .ok_or(format_err!("Ruby map not found for PID: {}", pid))?);
         let ruby_path = &ruby_map
@@ -252,7 +296,6 @@ mod os_impl {
             .expect("ruby map's pathname shouldn't be None");
         let ruby_elf = elf::File::open_path(ruby_path)
             .map_err(|_| format_err!("Couldn't open ELF file: {}", ruby_path))?;
-        let all_maps = get_proc_maps(pid).unwrap();
         let libruby_map = Box::new(get_map(&all_maps, "libruby", "r-xp"));
         let libruby_elf = match *libruby_map {
             Some(ref map) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,9 @@ extern crate rand;
 #[cfg(target_os = "macos")]
 extern crate regex;
 extern crate ruby_bindings as bindings;
+#[cfg(target_os = "linux")]
+#[macro_use]
+extern crate scopeguard;
 #[cfg(test)]
 extern crate tempdir;
 


### PR DESCRIPTION
Fixes #67.

This adds support for profiling Ruby processes running in Linux containers! 

The only reason rbspy **didn't** work with containers was -- there's a small part at the beginning of the program where it reads 1 or 2 binaries from the program's memory maps (the Ruby binary, and sometimes another dynamically linked library). 

It's also worth making "work with containers" more precise -- the real issue was that the target process was in a **different mount namespace** (/usr/bin/ruby1.9.1 in the target process didn't mean the same thing as /usr/bin/ruby1.9.1 in rbspy's process). 

So to make rbspy work with containerized processes, we just need to switch to the target process's mount namespace before reading those two ELF binaries. Then after reading the ELF binaries we switch back to our mount namespace right away so that we can write output to the filesystem in the right place. Pretty simple!

Originally I wanted to create a separate thread to do the namespace-switching juggle but it turns out that you can't run `setns` if your program has multiple threads. So switching & then switching back it is.