### PR TITLE
Mac support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,15 @@
 #
 # Changes:
 #   - no deb
-#   - no osx, 32-bit or ARM
-#   - darwin commented out for now
+#   - no 32-bit or ARM
 #   - no ARM
 
 language: rust
-cache: cargo
+cache:
+  cargo: true
+  directories:
+   - /home/travis/.rvm/
+   - /home/travis/.rbenv/
 
 services:
   - docker
@@ -23,7 +26,10 @@ env:
 # NOTE Make *sure* you don't remove a reference (&foo) if you are going to dereference it (*foo)
 matrix:
   include:
-    # stable channel
+    - os: osx
+      rust: stable
+      env: TARGET=x86_64-apple-darwin
+      sudo: required
     - os: linux
       rust: stable
       env: TARGET=x86_64-unknown-linux-musl
@@ -38,8 +44,8 @@ matrix:
 
 before_install:
   - export PATH="$PATH:$HOME/.cargo/bin"
-  - sudo apt-get update
-  - sudo apt-get -y install perl
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -y install perl; fi
 
 install:
   - bash ci/install.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,13 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "atty"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -37,9 +36,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -47,14 +46,9 @@ name = "backtrace-sys"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "bitflags"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
@@ -72,8 +66,22 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "byteorder"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bytes"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -92,11 +100,11 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.29.0"
+version = "2.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -127,7 +135,7 @@ name = "env_logger"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -137,7 +145,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -165,16 +173,8 @@ name = "flate2"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -188,21 +188,32 @@ dependencies = [
 
 [[package]]
 name = "fuchsia-zircon-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "getopts"
-version = "0.2.15"
+name = "gcc"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "goblin"
+version = "0.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -224,48 +235,49 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "libarchive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libarchive3-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "libarchive3-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.34"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libproc"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/andrewdavidmackenzie/libproc-rs.git#411d7f48458bcc04edd4b70a1a5e6909bc554628"
 dependencies = [
  "errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "mach"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mach"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -286,7 +298,7 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -294,7 +306,7 @@ name = "memchr"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -302,8 +314,8 @@ name = "miniz-sys"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -313,7 +325,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -324,7 +349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -332,7 +357,7 @@ name = "num-integer"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -341,12 +366,12 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -359,17 +384,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.9"
+name = "plain"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "quote"
@@ -378,11 +395,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -391,8 +408,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -401,23 +418,24 @@ version = "0.1.1"
 dependencies = [
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "elf 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libarchive3-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "libproc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mach 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libproc 0.1.0 (git+https://github.com/andrewdavidmackenzie/libproc-rs.git)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mach 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "object 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rbspy-testdata 0.1.0 (git+https://github.com/rbspy/rbspy-testdata.git)",
- "read-process-memory 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "read-process-memory 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruby-bindings 0.1.0",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -433,26 +451,25 @@ dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "read-process-memory 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "read-process-memory 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "read-process-memory"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mach 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "skeptic 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.32"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -460,7 +477,7 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -477,12 +494,12 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -494,7 +511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -515,18 +532,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "scroll"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scroll_derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "semver"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "skeptic"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "pulldown-cmark 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "strsim"
@@ -565,7 +590,7 @@ name = "tempdir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -573,8 +598,8 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -592,7 +617,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -617,9 +642,9 @@ name = "time"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -667,11 +692,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -681,12 +706,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -706,17 +731,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
-"checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
+"checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
-"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
-"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
+"checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
+"checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
+"checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
-"checksum clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "110d43e343eb29f4f51c1db31beb879d546db27998577e5715270a54bcf41d3f"
+"checksum clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4151c5790817c7d21bbdc6c3530811f798172915f93258244948b93ba19604a6"
 "checksum ctrlc 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "653abc99aa905f693d89df4797fadc08085baee379db92be9f2496cefe8a6f2c"
 "checksum elf 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4841de15dbe0e49b9b62a417589299e3be0d557e0900d36acb87e6dae47197f5"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
@@ -724,48 +750,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
-"checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
+"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum goblin 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2a5fea7ad351be7398e08003ea92a16bbba9a23c2a0c95d4e37d178276508217"
+"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
-"checksum libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3da06b22cd19af338a40f5d44a0aa6352ae43839d0855a049881cbc7e1b9c914"
-"checksum libarchive3-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3cd3beae8f59a4c7a806523269b5392037577c150446e88d684dfa6de6031ca7"
-"checksum libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "36fbc8a8929c632868295d0178dd8f63fc423fd7537ad0738372bd010b3ac9b0"
-"checksum libproc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7195fca750c0f31576e8fcf970f3074a577abbe80090e486ebb040e0a8713463"
-"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
+"checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
+"checksum libproc 0.1.0 (git+https://github.com/andrewdavidmackenzie/libproc-rs.git)" = "<none>"
+"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+"checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum mach 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "196697f416cf23cf0d3319cf5b2904811b035c82df1dfec2117fb457699bf277"
+"checksum mach 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
 "checksum mach_o 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "694cf810299b176946bb6b6722cae62c3b7029599d1572677dfee8dae1f10f30"
 "checksum mach_o_sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3e854583a83f20cf329bb9283366335387f7db59d640d1412167e05fedb98826"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
+"checksum nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fd5681d13fda646462cfbd4e5f2051279a89a544d50eb98c365b507246839f"
 "checksum nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2c5afeb0198ec7be8569d666644b574345aad2e95a53baf3a532da3e0f3fb32"
 "checksum num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "cc4083e14b542ea3eb9b5f33ff48bd373a92d78687e74f4cc0a30caeb754f0ca"
 "checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
-"checksum num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "cacfcab5eb48250ee7d0c7896b51a2c5eec99c1feea5f32025635f5ae4b00070"
+"checksum num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "9936036cc70fe4a8b2d338ab665900323290efb03983c86cbe235ae800ad8017"
 "checksum object 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ebe1b2d137eb894b8b9df5fbcbf5541b0f4c4f8cc60f7141204dd943b743ccb"
-"checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
-"checksum pulldown-cmark 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8361e81576d2e02643b04950e487ec172b687180da65c731c03cf336784e6c07"
+"checksum plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
+"checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rbspy-testdata 0.1.0 (git+https://github.com/rbspy/rbspy-testdata.git)" = "<none>"
-"checksum read-process-memory 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba4550193c685bc68ed91773485ac999d8654fa049366df582be3b3f7b15071"
-"checksum redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "ab105df655884ede59d45b7070c8a65002d921461ee813a024558ca16030eea0"
+"checksum read-process-memory 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "950b829b2477880c74aaed706d681bc8d50d4e2b15b5e4d98ed33d5d4f93712e"
+"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
-"checksum regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ac6ab4e9218ade5b423358bbd2567d1617418403c7a512603630181813316322"
+"checksum regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "744554e01ccbd98fff8c457c3b092cd67af62a555a43bfe97ae8a0451f7799fa"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
-"checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
+"checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum scroll 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b13864e1e0b3ed661d7206d512b8d1c4970f7fd9de23ae4e9b4331f0c25559e8"
+"checksum scroll_derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a67086db2a44e94311fc4c02ec3f4751bda0fca9d87fd4e1bfe1cef55e9411d"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
-"checksum skeptic 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "061203a849117b0f7090baf8157aa91dac30545208fbb85166ac58b4ca33d89c"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
@@ -785,9 +812,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b09fb3b6f248ea4cd42c9a65113a847d612e17505d6ebd1f7357ad68a8bf8693"
+"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec6667f60c23eca65c561e63a13d81b44234c2e38a6b6c959025ee907ec614cc"
-"checksum winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98f12c52b2630cd05d2c3ffd8e008f7f48252c042b4871c72aed9dc733b96668"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum xmas-elf 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "759bfa0300fef4cb3108880ba4965049c316c7acb27314b7df98dd94ae9f5d4e"
 "checksum zero 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f1bc8a6b2005884962297587045002d8cfb8dcec9db332f4ca216ddc5de82c5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 [workspace]
 
 [dependencies]
-libc = "0.2.15"
 chrono = "0.4"
 clap = "2"
 ctrlc = "3.1.0"
@@ -18,17 +17,18 @@ env_logger = "0.3.4"
 rand = "0.4"
 read-process-memory = "0.1.0"
 failure = "0.1.1"
-
 failure_derive = "0.1.1"
+nix = "0.10.0"
+libc = "0.2.34"
 ruby-bindings = { path = "ruby-bindings" }
 
 [target.'cfg(target_os="macos")'.dependencies]
-mach = "0.0.5"
+mach = "0.1.2"
 regex = "0.2.3"
-libproc = "0.1.0"
+libproc = {git="https://github.com/andrewdavidmackenzie/libproc-rs.git"}
+lazy_static = "1.0.0"
+goblin = "0.0.14"
 object = "0.1.0"
-libarchive = "0.1.1"
-libarchive3-sys = "0.1.2"
 
 [dev-dependencies]
 byteorder = "0.5"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ This is useful when you want to know what functions your program is spending mos
 
 ```
 sudo rbspy record --pid $PID
-# recording a subprocess doesn't require root access
+# recording a subprocess doesn't require root access on Linux
+# though on Mac rbspy always needs to run as root
 rbspy record ruby myprogram.rb
 ```
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -15,16 +15,22 @@ run_test_suite() {
     # sanity check the file type
     file target/$TARGET/debug/rbspy
 
-    sudo apt-get install -y libjemalloc1
-    sudo apt-get install -y libtcmalloc-minimal4
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]
+    then
+        sudo apt-get install -y libjemalloc1
+        sudo apt-get install -y libtcmalloc-minimal4
 
-    # test jemalloc + tcmalloc
-    target/$TARGET/debug/rbspy record env LD_PRELOAD=/usr/lib/libjemalloc.so.1 /usr/bin/ruby ci/ruby-programs/short_program.rb
-    target/$TARGET/debug/rbspy record env LD_PRELOAD=/usr/lib/libtcmalloc_minimal.so.4 /usr/bin/ruby ci/ruby-programs/short_program.rb
+        # test jemalloc + tcmalloc
+        target/$TARGET/debug/rbspy record env LD_PRELOAD=/usr/lib/libjemalloc.so.1 /usr/bin/ruby ci/ruby-programs/short_program.rb
+        target/$TARGET/debug/rbspy record env LD_PRELOAD=/usr/lib/libtcmalloc_minimal.so.4 /usr/bin/ruby ci/ruby-programs/short_program.rb
+    fi
 }
 
 run_docker_tests() {
-    bash $(dirname $0)/docker-tests.sh
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]
+    then
+        bash $(dirname $0)/docker-tests.sh
+    fi
 }
 
 main() {

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -46,6 +46,9 @@ where
     source.copy_address(addr as usize, &mut copy).map_err(|x| {
         if x.raw_os_error() == Some(3) {
             MemoryCopyError::ProcessEnded
+        } else if x.raw_os_error() == Some(60) {
+            // On Mac code 60 seems to more or less correspond to "process ended"
+            MemoryCopyError::ProcessEnded
         } else if x.kind() == std::io::ErrorKind::PermissionDenied {
             MemoryCopyError::PermissionDenied
         } else {

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -31,7 +31,7 @@ pub fn initialize(pid: pid_t) -> Result<StackTraceGetter, Error> {
 
     debug!("version: {}", version);
     Ok(StackTraceGetter {
-        pid: pid,
+        process_handle: pid.try_into_process_handle()?,
         current_thread_addr_location: address_finder::current_thread_address(
             pid,
             &version,
@@ -75,7 +75,7 @@ impl PartialOrd for StackFrame {
 
 // Use a StackTraceGetter to get stack traces
 pub struct StackTraceGetter {
-    pid: pid_t,
+    process_handle: ProcessHandle,
     current_thread_addr_location: usize,
     stack_trace_function:
         Box<Fn(usize, &ProcessHandle) -> Result<Vec<StackFrame>, MemoryCopyError>>,
@@ -92,7 +92,7 @@ impl StackTraceGetter {
         let stack_trace_function = &self.stack_trace_function;
         stack_trace_function(
             self.current_thread_addr_location,
-            &self.pid.try_into_process_handle().unwrap(),
+            &self.process_handle,
         )
     }
 }
@@ -103,8 +103,11 @@ fn get_ruby_version_retry(pid: pid_t) -> Result<String, Error> {
     // this exists because sometimes rbenv takes a while to exec the right Ruby binary.
     // we are dumb right now so we just... wait until it seems to work out.
     let mut i = 0;
+    let source = &pid.try_into_process_handle().context(
+        "Couldn't connect to PID",
+    )?;
     loop {
-        let version = get_ruby_version(pid);
+        let version = get_ruby_version(pid, source);
         if i > 100 {
             return Ok(version?);
         }
@@ -112,6 +115,9 @@ fn get_ruby_version_retry(pid: pid_t) -> Result<String, Error> {
             Err(err) => {
                 match err.root_cause().downcast_ref::<AddressFinderError>() {
                     Some(&AddressFinderError::PermissionDenied(_)) => {
+                        return Err(err.into());
+                    }
+                    Some(&AddressFinderError::MacPermissionDenied(_)) => {
                         return Err(err.into());
                     }
                     Some(&AddressFinderError::NoSuchProcess(_)) => {
@@ -136,9 +142,9 @@ fn get_ruby_version_retry(pid: pid_t) -> Result<String, Error> {
     }
 }
 
-pub fn get_ruby_version(pid: pid_t) -> Result<String, Error> {
+pub fn get_ruby_version(pid: pid_t, source: &ProcessHandle) -> Result<String, Error> {
     let addr = address_finder::get_ruby_version_address(pid)?;
-    let x: [c_char; 15] = copy_struct(addr, &pid.try_into_process_handle().unwrap())?;
+    let x: [c_char; 15] = copy_struct(addr, source)?;
     Ok(unsafe {
         std::ffi::CStr::from_ptr(x.as_ptr() as *mut c_char)
             .to_str()?
@@ -147,33 +153,35 @@ pub fn get_ruby_version(pid: pid_t) -> Result<String, Error> {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn test_get_nonexistent_process() {
     let version = get_ruby_version_retry(10000);
     match version
         .unwrap_err()
         .root_cause()
         .downcast_ref::<AddressFinderError>()
-        .unwrap()
-    {
+        .unwrap() {
         &AddressFinderError::NoSuchProcess(10000) => {}
         _ => assert!(false, "Expected NoSuchProcess error"),
     }
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn test_get_disallowed_process() {
     let version = get_ruby_version_retry(1);
     match version
         .unwrap_err()
         .root_cause()
         .downcast_ref::<AddressFinderError>()
-        .unwrap()
-    {
+        .unwrap() {
         &AddressFinderError::PermissionDenied(1) => {}
         _ => assert!(false, "Expected NoSuchProcess error"),
     }
 }
+
 #[test]
+#[cfg(target_os = "linux")]
 fn test_current_thread_address() {
     let mut process = std::process::Command::new("/usr/bin/ruby").spawn().unwrap();
     let pid = process.id() as pid_t;
@@ -181,6 +189,25 @@ fn test_current_thread_address() {
     let is_maybe_thread = is_maybe_thread_function(&version);
     let result = address_finder::current_thread_address(pid, &version, is_maybe_thread);
     assert!(result.is_ok(), format!("result not ok: {:?}", result));
+    process.kill().unwrap();
+}
+
+
+#[test]
+#[cfg(target_os = "macos")]
+fn test_get_nonexistent_process() {
+    let version = get_ruby_version_retry(10000);
+    assert!(version.is_err());
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn test_get_disallowed_process() {
+    // getting the ruby version isn't allowed on Mac if the process isn't running as root
+    let mut process = std::process::Command::new("/usr/bin/ruby").spawn().unwrap();
+    let pid = process.id() as pid_t;
+    let version = get_ruby_version_retry(pid);
+    assert!(version.is_err());
     process.kill().unwrap();
 }
 

--- a/src/mac_maps.rs
+++ b/src/mac_maps.rs
@@ -1,0 +1,151 @@
+use std;
+use std::io;
+use std::mem;
+use failure::Error;
+use libc::{c_int, pid_t};
+use mach::kern_return::KERN_SUCCESS;
+use mach::port::{mach_port_name_t, mach_port_t, MACH_PORT_NULL};
+use mach::vm_types::{mach_vm_address_t, mach_vm_size_t};
+use mach::message::mach_msg_type_number_t;
+use mach::vm_region::{vm_region_basic_info_data_t, vm_region_info_t,
+                      vm_region_basic_info_data_64_t, VM_REGION_BASIC_INFO};
+use mach::types::vm_task_entry_t;
+use libproc::libproc::proc_pid::regionfilename;
+use mach;
+
+#[derive(Debug, Clone)]
+pub struct MacMapRange {
+    pub size: mach_vm_size_t,
+    pub info: vm_region_basic_info_data_t,
+    pub start: mach_vm_address_t,
+    pub count: mach_msg_type_number_t,
+    pub filename: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Symbol {
+    pub value: Option<usize>,
+    pub typ: String,
+    pub name: String,
+}
+
+fn parse_nm_output(output: &str) -> Vec<Symbol> {
+    let mut vec = vec![];
+    for line in output.split("\n") {
+        let mut split: Vec<&str> = line.split_whitespace().collect();
+        let sym = if split.len() == 2 {
+            Symbol {
+                value: None,
+                typ: split[0].to_string(),
+                name: split[1].to_string(),
+            }
+        } else if split.len() == 3 {
+            let value = usize::from_str_radix(split[0], 16).unwrap();
+            Symbol {
+                value: Some(value),
+                typ: split[1].to_string(),
+                name: split[2].to_string(),
+            }
+        } else {
+            continue;
+        };
+        vec.push(sym);
+    }
+    vec
+}
+
+pub fn get_symbols(filename: &str) -> Result<Vec<Symbol>, Error> {
+    let output = std::process::Command::new("nm").arg(filename).output()?;
+    Ok(parse_nm_output(&String::from_utf8_lossy(&output.stdout)))
+}
+
+impl MacMapRange {
+    pub fn end(&self) -> mach_vm_address_t {
+        self.start + self.size as mach_vm_address_t
+    }
+
+    pub fn is_read(&self) -> bool {
+        self.info.protection & mach::vm_prot::VM_PROT_READ != 0
+    }
+    pub fn is_write(&self) -> bool {
+        self.info.protection & mach::vm_prot::VM_PROT_WRITE != 0
+    }
+    pub fn is_exec(&self) -> bool {
+        self.info.protection & mach::vm_prot::VM_PROT_EXECUTE != 0
+    }
+}
+
+/*
+ * The way the `mach_vm_region` API works is a bit weird -- you give it an address, and then it
+ * returns the first memory map in the process **after** that address. So we start by passing it `1`
+ * to get the first memory map in the process, pass the end of that memory map to get the second
+ * memory map, etc.
+ */
+pub fn get_process_maps(pid: pid_t, task: mach_port_name_t) -> Vec<MacMapRange> {
+    let init_region = mach_vm_region(pid, task, 1).unwrap();
+    let mut vec = vec![];
+    let mut region = init_region.clone();
+    vec.push(init_region);
+    loop {
+        match mach_vm_region(pid, task, region.end()) {
+            Some(r) => {
+                vec.push(r.clone());
+                region = r;
+            }
+            _ => return vec,
+        }
+    }
+}
+
+fn mach_vm_region(
+    pid: pid_t,
+    target_task: mach_port_name_t,
+    mut address: mach_vm_address_t,
+) -> Option<MacMapRange> {
+    let mut count = mem::size_of::<vm_region_basic_info_data_64_t>() as mach_msg_type_number_t;
+    let mut object_name: mach_port_t = 0;
+    let mut size = unsafe { mem::zeroed::<mach_vm_size_t>() };
+    let mut info = unsafe { mem::zeroed::<vm_region_basic_info_data_t>() };
+    let result = unsafe {
+        mach::vm::mach_vm_region(
+            target_task as vm_task_entry_t,
+            &mut address,
+            &mut size,
+            VM_REGION_BASIC_INFO,
+            &mut info as *mut vm_region_basic_info_data_t as vm_region_info_t,
+            &mut count,
+            &mut object_name,
+        )
+    };
+    if result != KERN_SUCCESS {
+        return None;
+    }
+    let filename = match regionfilename(pid, address) {
+        Ok(x) => Some(x),
+        _ => None,
+    };
+    Some(MacMapRange {
+        size: size,
+        info: info,
+        start: address,
+        count: count,
+        filename: filename,
+    })
+}
+
+pub fn task_for_pid(pid: pid_t) -> io::Result<mach_port_name_t> {
+    let mut task: mach_port_name_t = MACH_PORT_NULL;
+    // sleep for 5ms to make sure we don't get into a race between `task_for_pid` and execing a new
+    // process. Races here can freeze the OS because of a Mac kernel bug on High Sierra.
+    // See https://jvns.ca/blog/2018/01/28/mac-freeze/ for more.
+    std::thread::sleep(std::time::Duration::from_millis(5));
+    unsafe {
+        let result =
+            mach::traps::task_for_pid(mach::traps::mach_task_self(), pid as c_int, &mut task);
+        if result != KERN_SUCCESS {
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    Ok(task)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,16 @@ extern crate elf;
 extern crate env_logger;
 #[macro_use]
 extern crate failure;
+#[cfg(target_os = "macos")]
+extern crate goblin;
 #[macro_use]
 extern crate failure_derive;
 extern crate libc;
+#[cfg(target_os = "macos")]
+extern crate libproc;
+#[cfg(target_os = "macos")]
+extern crate mach;
+extern crate nix;
 #[macro_use]
 extern crate log;
 extern crate rand;
@@ -21,6 +28,8 @@ extern crate rbspy_testdata;
 extern crate read_process_memory;
 #[cfg(target_os = "macos")]
 extern crate regex;
+#[cfg(target_os = "macos")]
+extern crate lazy_static;
 extern crate ruby_bindings as bindings;
 #[cfg(test)]
 extern crate tempdir;
@@ -37,8 +46,11 @@ use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
+use std::os::unix::prelude::*;
 
 pub mod proc_maps;
+#[cfg(target_os = "macos")]
+pub mod mac_maps;
 pub mod address_finder;
 pub mod initialize;
 pub mod copy;
@@ -75,6 +87,7 @@ enum SubCmd {
         sample_rate: u32,
         maybe_duration: Option<std::time::Duration>,
         format: OutputFormat,
+        no_drop_root: bool,
     },
     /// Capture and print a stacktrace snapshot of process `pid`.
     Snapshot { pid: pid_t },
@@ -101,11 +114,24 @@ fn do_main() -> Result<(), Error> {
             sample_rate,
             maybe_duration,
             format,
+            no_drop_root,
         } => {
             let pid = match target {
                 Pid { pid } => pid,
                 Subprocess { prog, args } => {
-                    Command::new(prog).args(args).spawn()?.id() as pid_t
+                    let uid_str = std::env::var("SUDO_UID");
+                    if nix::unistd::Uid::effective().is_root() && !no_drop_root && uid_str.is_ok() {
+                        let uid: u32 = uid_str.unwrap().parse::<u32>().context(
+                            "Failed to parse UID",
+                        )?;
+                        eprintln!(
+                            "Dropping permissions: running Ruby command as user {}",
+                            std::env::var("SUDO_USER")?
+                        );
+                        Command::new(prog).uid(uid).args(args).spawn()?.id() as pid_t
+                    } else {
+                        Command::new(prog).args(args).spawn()?.id() as pid_t
+                    }
                 }
             };
 
@@ -120,7 +146,26 @@ fn do_main() -> Result<(), Error> {
     }
 }
 
+fn sudo_if_not_root() -> bool {
+    let euid = nix::unistd::Uid::effective();
+    if euid.is_root() {
+        return true;
+    } else {
+        println!("rbspy only works as root on Mac. Try rerunning with `sudo --preserve-env !!`.");
+        println!(
+            "If you run `sudo rbspy record ruby your-program.rb`, rbspy will drop privileges when running `ruby your-program.rb`. If you want the Ruby program to run as root, use `rbspy --no-drop-root`."
+        );
+        return false;
+    }
+}
+
 fn main() {
+    if cfg!(target_os = "macos") {
+        let ok = sudo_if_not_root();
+        if !ok {
+            return;
+        }
+    }
     match do_main() {
         Err(x) => {
             eprintln!("Error. Causes: ");
@@ -347,6 +392,10 @@ fn arg_parser() -> App<'static, 'static> {
                         .required(false),
                 )
                 .arg(
+                    Arg::from_usage("--no-drop-root 'Don't drop root privileges when running a Ruby program as a subprocess'")
+                        .required(false),
+                )
+                .arg(
                     Arg::from_usage("--format=[FORMAT] 'Output format to write'")
                         .possible_values(&OutputFormat::variants())
                         .case_insensitive(true)
@@ -394,6 +443,8 @@ impl Args {
                     Ok(integer_duration) => Some(std::time::Duration::from_secs(integer_duration)),
                 };
 
+                let no_drop_root = submatches.occurrences_of("no-drop-root") == 1;
+
                 let sample_rate = value_t!(submatches, "rate", u32).unwrap_or(100);
                 let target = if let Some(pid) = get_pid(submatches) {
                     Pid { pid }
@@ -413,6 +464,7 @@ impl Args {
                     sample_rate,
                     maybe_duration,
                     format,
+                    no_drop_root,
                 }
             }
             _ => panic!("this shouldn't happen, please report the command you ran!"),
@@ -478,6 +530,7 @@ mod tests {
                     sample_rate: 100,
                     maybe_duration: None,
                     format: OutputFormat::Flamegraph,
+                    no_drop_root: false,
                 },
             }
         );
@@ -494,6 +547,7 @@ mod tests {
                     sample_rate: 25,
                     maybe_duration: None,
                     format: OutputFormat::Flamegraph,
+                    no_drop_root: false,
                 },
             }
         );
@@ -510,6 +564,7 @@ mod tests {
                     sample_rate: 100,
                     maybe_duration: Some(std::time::Duration::from_secs(60)),
                     format: OutputFormat::Flamegraph,
+                    no_drop_root: false,
                 },
             }
         );
@@ -526,6 +581,24 @@ mod tests {
                     sample_rate: 100,
                     maybe_duration: Some(std::time::Duration::from_secs(60)),
                     format: OutputFormat::Callgrind,
+                    no_drop_root: false,
+                },
+            }
+        );
+
+        let args = Args::from(make_args(
+            "rbspy record --pid 1234 --file foo.txt --format callgrind --no-drop-root",
+        )).unwrap();
+        assert_eq!(
+            args,
+            Args {
+                cmd: Record {
+                    target: Pid { pid: 1234 },
+                    out_path: "foo.txt".into(),
+                    sample_rate: 100,
+                    maybe_duration: None,
+                    format: OutputFormat::Callgrind,
+                    no_drop_root: true,
                 },
             }
         );


### PR DESCRIPTION
Preliminary Mac support! In my testing so far, this works with Ruby (as long as it's installed by rbenv) on Mac.

This does **not** work with system Ruby on Mac. There are a couple issues with adding system Ruby support:

1. SIP -- getting a port to talk to system Ruby is impossible if you have SIP enabled on your Mac (tested this today). I believe this isn't fixable, the whole point of SIP is to prevent other programs from instrumenting your program in exactly this way.
2. my implementation of `get_process_maps` right now doesn't support dynamically loaded libraries, and all the symbols in system Ruby (at least on the High Sierra mac I'm working with) are in a dynamically loaded library which I haven't been about to find the address or path of yet. more notes about the difficulties there in [this blog post I wrote today](https://jvns.ca/blog/2018/01/26/mac-memory-maps/)

issue 2 there is definitely possible to work around but I think it might take me another 2 days so I think it's probably better to merge this as is. (and the SIP issue makes me wonder if it's even worth trying to support system Ruby, my guess is most people have SIP enabled)

Still need to add CI for Mac but wanted to get this out there.