### PR TITLE
Write flamegraph when we record for a duration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,12 @@ fn snapshot(pid: pid_t) -> Result<(), Error> {
 }
 
 fn record(output_filename: &Path, pid: pid_t, sample_rate: u32, maybe_duration: Option<std::time::Duration>, is_subcommand: bool) -> Result<(), Error> {
+    do_record(output_filename, pid, sample_rate, maybe_duration, is_subcommand)?;
+    write_flamegraph(output_filename)?;
+    Ok(())
+}
+
+fn do_record(output_filename: &Path, pid: pid_t, sample_rate: u32, maybe_duration: Option<std::time::Duration>, is_subcommand: bool) -> Result<(), Error> {
     // This gets a stack trace and then just prints it out
     // in a format that Brendan Gregg's stackcollapse.pl script understands
     let getter = initialize::initialize(pid)?;
@@ -160,7 +166,6 @@ fn record(output_filename: &Path, pid: pid_t, sample_rate: u32, maybe_duration: 
         match trace {
             Err(copy::MemoryCopyError::ProcessEnded) => {
                 print_errors(errors, total);
-                write_flamegraph(&output_filename).context("Failed to write flamegraph")?;
                 return Ok(())
             },
             Ok(ref ok_trace) => {


### PR DESCRIPTION
Just noticed that when we were recording for a duration, it wouldn't write a flamegraph at the end. This should fix that! It felt like there were a lot of calls to `write_flamegraph` to keep track of so I thought it would be better to restructure the code a tiny bit to ensure that we always call `write_flamegraph` after we finish recording.