### PR TITLE
Add callgrind output

### DIFF
--- a/src/callgrind.rs
+++ b/src/callgrind.rs
@@ -1,0 +1,215 @@
+use std::cmp::min;
+use std::collections::HashMap;
+use std::io;
+
+use initialize::StackFrame;
+
+#[derive(Debug)]
+struct Call {
+    count: usize,
+    inclusive: usize,
+}
+
+#[derive(Debug, Default)]
+struct Location {
+    exclusive: usize,
+    calls: HashMap<StackFrame, Call>,
+}
+
+#[derive(Default, Debug)]
+struct Locations(HashMap<StackFrame, Location>);
+
+#[derive(Debug)]
+struct StackEntry {
+    frame: StackFrame,
+    exclusive: usize,
+    inclusive: usize,
+}
+
+#[derive(Default, Debug)]
+pub struct Stats {
+    // Stored with the root of the callgraph at the start.
+    stack: Vec<StackEntry>,
+    locations: Locations,
+}
+
+impl Locations {
+    fn location(&mut self, frame: &StackFrame) -> &mut Location {
+        if !self.0.contains_key(frame) {
+            let loc = Location {
+                ..Default::default()
+            };
+            self.0.insert(frame.clone(), loc);
+        }
+        self.0.get_mut(frame).unwrap()
+    }
+
+    fn add_exclusive(&mut self, entry: &StackEntry) {
+        self.location(&entry.frame).exclusive += entry.exclusive;
+    }
+
+    fn add_inclusive(&mut self, parent: &StackFrame, child: &StackEntry) {
+        let ploc = self.location(parent);
+        let val = ploc.calls.entry(child.frame.clone()).or_insert(Call {
+            count: 0,
+            inclusive: 0,
+        });
+        val.count += 1;
+        val.inclusive += child.inclusive;
+    }
+}
+
+impl Stats {
+    pub fn new() -> Stats {
+        Stats {
+            ..Default::default()
+        }
+    }
+
+    pub fn add(&mut self, stack: &Vec<StackFrame>) {
+        // We get input with the root of the callgraph at the end. Reverse that!
+        let rev: Vec<_> = stack.iter().rev().collect();
+
+        // Skip any common items
+        let mut common = 0;
+        let max_common = min(self.stack.len(), rev.len());
+        while common < max_common && &self.stack[common].frame == rev[common] {
+            common += 1;
+        }
+
+        // Pop old items
+        while self.stack.len() > common {
+            let entry = self.stack.pop().unwrap();
+            self.locations.add_exclusive(&entry);
+            if let Some(parent) = self.stack.last_mut() {
+                self.locations.add_inclusive(&parent.frame, &entry);
+                parent.inclusive += entry.inclusive;
+            }
+        }
+
+        // Add new items
+        for i in common..rev.len() {
+            self.stack.push(StackEntry {
+                frame: rev[i].clone(),
+                exclusive: 0,
+                inclusive: 0,
+            })
+        }
+
+        // Count the current entry
+        if let Some(entry) = self.stack.last_mut() {
+            entry.exclusive += 1;
+            entry.inclusive += 1;
+        }
+    }
+
+    pub fn finish(&mut self) {
+        self.add(&vec![]);
+    }
+
+    pub fn write(&self, w: &mut io::Write) -> io::Result<()> {
+        // TODO
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use callgrind::*;
+
+    // Build a test stackframe
+    fn f(i: u32) -> StackFrame {
+        StackFrame {
+            name: format!("func{}", i),
+            relative_path: format!("file{}.rb", i),
+            absolute_path: None,
+            lineno: i,
+        }
+    }
+
+    // A stack frame from the same file as another one
+    fn fdup() -> StackFrame {
+        StackFrame {
+            name: "funcX".to_owned(),
+            relative_path: "file1.rb".to_owned(),
+            absolute_path: None,
+            lineno: 42,
+        }
+    }
+
+    fn assert_location(stats: &Stats, f: StackFrame, exclusive: usize, children: usize) {
+        let loc = stats
+            .locations
+            .0
+            .get(&f)
+            .expect(format!("No location for {}", f).as_ref());
+        assert_eq!(loc.exclusive, exclusive, "Bad exclusive time for {}", f,);
+        assert_eq!(loc.calls.len(), children, "Bad children count for {}", f,);
+    }
+
+    fn assert_inclusive(
+        stats: &Stats,
+        parent: StackFrame,
+        child: StackFrame,
+        count: usize,
+        inclusive: usize,
+    ) {
+        let ploc = stats
+            .locations
+            .0
+            .get(&parent)
+            .expect(format!("No location for {}", parent).as_ref());
+        let call = ploc.calls
+            .get(&child)
+            .expect(format!("No call of {} in {}", child, parent).as_ref());
+        assert_eq!(
+            call.count,
+            count,
+            "Bad inclusive count for {} in {}",
+            child,
+            parent,
+        );
+        assert_eq!(
+            call.inclusive,
+            inclusive,
+            "Bad inclusive time for {} in {}",
+            child,
+            parent,
+        )
+    }
+
+    fn build_test_stats() -> Stats {
+        let mut stats = Stats::new();
+
+        stats.add(&vec![f(1)]);
+        stats.add(&vec![f(3), f(2), f(1)]);
+        stats.add(&vec![f(2), f(1)]);
+        stats.add(&vec![f(3), f(1)]);
+        stats.add(&vec![f(2), f(1)]);
+        stats.add(&vec![f(3), fdup(), f(1)]);
+        stats.finish();
+
+        stats
+    }
+
+    #[test]
+    fn stats_aggregate() {
+        let stats = &build_test_stats();
+        assert!(
+            stats.stack.is_empty(),
+            "Stack not empty: {:#?}",
+            stats.stack
+        );
+        let len = stats.locations.0.len();
+        assert_eq!(len, 4, "Bad location count");
+        assert_location(stats, f(1), 1, 3);
+        assert_location(stats, f(2), 2, 1);
+        assert_location(stats, f(3), 3, 0);
+        assert_location(stats, f(4), 0, 1);
+        assert_inclusive(stats, f(1), f(2), 3);
+        assert_inclusive(stats, f(1), f(3), 1);
+        assert_inclusive(stats, f(1), f(4), 1);
+        assert_inclusive(stats, f(2), f(3), 1);
+        assert_inclusive(stats, f(4), f(3), 1);
+    }
+}

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -40,7 +40,7 @@ pub fn initialize(pid: pid_t) -> Result<StackTraceGetter, Error> {
     })
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct StackFrame {
     pub name: String,
     pub relative_path: String,

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -3,6 +3,7 @@ use copy;
 use failure::Error;
 use failure::ResultExt;
 use libc::{c_char, pid_t};
+use std::cmp::Ordering;
 use std::fmt;
 use std::time::Duration;
 use std;
@@ -57,6 +58,20 @@ impl StackFrame {
     }
 }
 
+impl Ord for StackFrame {
+    fn cmp(&self, other: &StackFrame) -> Ordering {
+        self.path()
+            .cmp(other.path())
+            .then(self.name.cmp(&other.name))
+            .then(self.lineno.cmp(&other.lineno))
+    }
+}
+
+impl PartialOrd for StackFrame {
+    fn partial_cmp(&self, other: &StackFrame) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 // Use a StackTraceGetter to get stack traces
 pub struct StackTraceGetter {

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -48,6 +48,16 @@ pub struct StackFrame {
     pub lineno: u32,
 }
 
+impl StackFrame {
+    pub fn path(&self) -> &str {
+        match self.absolute_path {
+            Some(ref p) => p.as_ref(),
+            None => self.relative_path.as_ref(),
+        }
+    }
+}
+
+
 // Use a StackTraceGetter to get stack traces
 pub struct StackTraceGetter {
     pid: pid_t,
@@ -58,11 +68,7 @@ pub struct StackTraceGetter {
 
 impl fmt::Display for StackFrame {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(abspath) = self.absolute_path.as_ref() {
-            write!(f, "{} - {} line {}", self.name, abspath, self.lineno)
-        } else {
-            write!(f, "{} - {} line {}", self.name, self.relative_path, self.lineno)
-        }
+        write!(f, "{} - {} line {}", self.name, self.path(), self.lineno)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ pub mod address_finder;
 pub mod initialize;
 pub mod copy;
 pub mod ruby_version;
+pub mod callgrind;
 
 const FLAMEGRAPH_SCRIPT: &'static [u8] = include_bytes!("../vendor/flamegraph/flamegraph.pl");
 const BILLION: u32 = 1000 * 1000 * 1000; // for nanosleep

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,71 @@
+#[cfg(test)]
+extern crate tempdir;
+
+use failure::{Error, ResultExt};
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use initialize::StackFrame;
+
+const FLAMEGRAPH_SCRIPT: &'static [u8] = include_bytes!("../vendor/flamegraph/flamegraph.pl");
+
+pub trait Outputter {
+    fn record(&mut self, file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error>;
+    fn complete(&mut self, path: &Path, file: File) -> Result<(), Error>;
+}
+
+// This gets a stack trace and then just prints it out
+// in a format that Brendan Gregg's stackcollapse.pl script understands
+pub struct Flamegraph;
+
+impl Outputter for Flamegraph {
+    fn record(&mut self, file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error> {
+        for t in stack.iter().rev() {
+            write!(file, "{}", t)?;
+            write!(file, ";")?;
+        }
+        writeln!(file, " {}", 1)?;
+        Ok(())
+    }
+
+    fn complete(&mut self, path: &Path, file: File) -> Result<(), Error> {
+        drop(file); // close it!
+        write_flamegraph(path).context("Writing flamegraph failed")?;
+        Ok(())
+    }
+}
+
+#[test]
+fn test_write_flamegraph() {
+    let tempdir = tempdir::TempDir::new("flamegraph").unwrap();
+    let stacks_file = tempdir.path().join("stacks.txt");
+    let mut file = File::create(&stacks_file).expect("couldn't create file");
+    for _ in 1..10 {
+        file.write(b"a;a;a;a 1").unwrap();
+    }
+    write_flamegraph(stacks_file.to_str().unwrap()).expect("Couldn't write flamegraph");
+    tempdir.close().unwrap();
+}
+
+fn write_flamegraph<P: AsRef<Path>>(stacks_filename: P) -> Result<(), Error> {
+    let stacks_filename = stacks_filename.as_ref();
+    let svg_filename = stacks_filename.with_extension("svg");
+    let output_svg = File::create(&svg_filename)?;
+    eprintln!("Writing flamegraph to {}", svg_filename.display());
+    let mut child = Command::new("perl")
+        .arg("-")
+        .arg(stacks_filename)
+        .stdin(Stdio::piped())
+        .stdout(output_svg)
+        .spawn()
+        .context("Couldn't execute perl")?;
+    // TODO(nll): Remove this silliness after non-lexical lifetimes land.
+    {
+        let stdin = child.stdin.as_mut().expect("failed to write to stdin");
+        stdin.write_all(FLAMEGRAPH_SCRIPT)?;
+    }
+    child.wait()?;
+    Ok(())
+}


### PR DESCRIPTION
## Why?

Flamegraphs are awesome! But sometimes there are better ways to visualize your program.

For example, here's the [dumbest fibonacci calculator ever](https://gist.github.com/vasi/ae3b25ce7bfd7540be6c3970b9a0a4f6), and the flamegraph rbspy generates:

![image](https://user-images.githubusercontent.com/3305/35481176-946d6cf8-03ec-11e8-862c-6c52fe3d13f1.png)

It's super hard to tell what's wrong. Even though `fib0` is being called a gazillion times and doing loads of work, it doesn't really show up. On the other hand, I can run.:

```
sudo ./target/debug/rbspy record -f ../callgrind.out --format callgrind ./fib.rb 19
```

And then open `callgrind.out` with [qcachegrind](https://kcachegrind.github.io/html/Home.html), I get some really useful output:

![image](https://user-images.githubusercontent.com/3305/35481238-d6c67558-03ed-11e8-99c6-b2826a70bb07.png)

Clearly "block in fib0" has something wrong!

### Bonus!

* qcachegrind can do some nice visualizations:
![image](https://user-images.githubusercontent.com/3305/35481249-079b45d2-03ee-11e8-8e05-1c9a79021d1b.png)
* callgrind files are much smaller than flamegraphs—easier to collect for future analysis or share with friends

## What's changed

* A new argument `--format=` allows specifying either `flamegraph` (default) or `callgrind`
* `callgrind.rs` contains code to aggregate stack traces, and to write the callgrind file format
* `output.rs` takes over the flamegraph code, and adds some glue for callgrind
* `record()` now takes an `Outputter` as an argument, and uses that to do all the real work. I think this overall makes it cleaner
    * It now has fewer exit points—all success-like ones (ctrl-c, program finished, duration expired) go through the same exit.
    * This also fixes a bug where duration-expired wouldn't cause the flamegraph to be written

## Caveats

* The "number of times each function is called" is inaccurate. This is because if two samples have identical call stacks, we have no way to tell whether there have been intermediate changes. Maybe there's a way to get this info from Ruby.
* Other formats (pprof, perf, gprof...) might be more useful in some situations. But callgrind is [well-specified](http://valgrind.org/docs/manual/cl-format.html) and text-based, so much easier to implement.
* My Rust is pretty awful, a lot of StackFrames are getting copied for no good reason. Not sure if that's fixable!
