### PR TITLE
Display StackFrames in the Ruby Kernel#caller format.

### DIFF
--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -83,7 +83,7 @@ pub struct StackTraceGetter {
 
 impl fmt::Display for StackFrame {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} - {} line {}", self.name, self.path(), self.lineno)
+        write!(f, "{1}:{2}:in `{0}'", self.name, self.path(), self.lineno)
     }
 }
 


### PR DESCRIPTION
Example:

If we take the "Dumbest Fibonacci ever" program used in the Callgrind
PR, https://gist.github.com/vasi/ae3b25ce7bfd7540be6c3970b9a0a4f6
it looks like this:

```
$ ruby /tmp/fib.rb 22 &
$ sudo ./target/debug/rbspy snapshot --pid $(pgrep -f fib.rb)
/tmp/fib.rb:163:in `<main>'
/tmp/fib.rb:159:in `fib'
/tmp/fib.rb:113:in `fib22'
/tmp/fib.rb:108:in `fib21'
/tmp/fib.rb:103:in `fib20'
/tmp/fib.rb:98:in `fib19'
/tmp/fib.rb:88:in `fib17'
/tmp/fib.rb:83:in `fib16'
/tmp/fib.rb:78:in `fib15'
/tmp/fib.rb:73:in `fib14'
/tmp/fib.rb:68:in `fib13'
/tmp/fib.rb:63:in `fib12'
/tmp/fib.rb:53:in `fib10'
/tmp/fib.rb:48:in `fib9'
/tmp/fib.rb:38:in `fib7'
/tmp/fib.rb:33:in `fib6'
/tmp/fib.rb:23:in `fib4'
/tmp/fib.rb:13:in `fib2'
/tmp/fib.rb:4:in `fib0'
/tmp/fib.rb:4:in `block in fib0'
```

This changes the default output format. If something relies on
the original format I will be happy to add command line switches
for the formats.

My biggest motivation is to use the colon-delimited filename:line
format because it is common in compiler output and many tools
know how to open such locations in code editors.

I actually hate the backtick quote in the output because it messes up 
syntax highlighters, but I think it is valuable to have exact 
compatibility of the output. 