### PR TITLE
Add more sleeps to prevent freezing on High Sierra

### DIFF
--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -206,6 +206,9 @@ fn test_get_disallowed_process() {
     // getting the ruby version isn't allowed on Mac if the process isn't running as root
     let mut process = std::process::Command::new("/usr/bin/ruby").spawn().unwrap();
     let pid = process.id() as pid_t;
+    // sleep to prevent freezes (because of High Sierra kernel bug)
+    // TODO: figure out how to work around this race in a cleaner way
+    std::thread::sleep(std::time::Duration::from_millis(10));
     let version = get_ruby_version_retry(pid);
     assert!(version.is_err());
     process.kill().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,11 @@ fn do_main() -> Result<(), Error> {
                 Pid { pid } => pid,
                 Subprocess { prog, args } => {
                     let uid_str = std::env::var("SUDO_UID");
+                    if cfg!(target_os = "macos") {
+                        // sleep to prevent freezes (because of High Sierra kernel bug)
+                        // TODO: figure out how to work around this race in a cleaner way
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
                     if nix::unistd::Uid::effective().is_root() && !no_drop_root && uid_str.is_ok() {
                         let uid: u32 = uid_str.unwrap().parse::<u32>().context(
                             "Failed to parse UID",


### PR DESCRIPTION
I realized the existing sleep (in `task_for_pid` in mac_maps.rs) isn't enough to prevent the race between task_for_pid and exec'ing a process that causes freezes in High Sierra.

I think these are the only other 2 places that need it right now. I'd rather write this code in a cleaner way but I'm not seeing how to do it right now -- it's annoying because we both start processes and run `task_for_pid` in several places (through both `.try_into_process_handle` and `task_for_pid` directly). Probably worth refactoring later so that there's only one place that PIDs get translated into Mach tasks on Mac, and then we can make sure to always sleep there.