### PR TITLE
Turn overflow panic in get_lineno into error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "rbspy"
-version = "0.1.1"
+version = "0.1.8"
 dependencies = [
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -13,7 +13,7 @@ pub enum MemoryCopyError {
     PermissionDenied,
     #[fail(display = "Failed to copy memory address {:x}", _0)] Io(usize, #[cause] std::io::Error),
     #[fail(display = "Process isn't running")] ProcessEnded,
-    #[fail(display = "Other")] Other,
+    #[fail(display = "Copy error: {}", _0)] Message(String),
     #[fail(display = "Too much memory requested when copying: {}", _0)] RequestTooLarge(usize),
     #[fail(display = "Tried to read invalid string")]
     InvalidStringError(#[cause] std::string::FromUtf8Error),


### PR DESCRIPTION
Fixes #87 

get_lineno was panicking because of an overflow -- we were sometimes subtracing two usizes `a-b` where `a < b`. I'm pretty sure this is because rbspy is in a race trying to read memory. The way we're handling these errors elsewhere is just to return an error and then possibly retry.

So this adds a check to see if `a < b` and if so returns an error. If `a >= b`, then doing the subtraction is fine.