### PR TITLE
remove "Mac support" from Missing Features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ you're seeing high error rates (more than 1/100 or so), please create an issue.
 
 Contributions in any of these areas would be very welcome.
 
-* Mac support
 * BSD/Windows support
 * Profile multiple threads
 * Profile C extensions (rbspy will simply ignore any calls into C extensions)


### PR DESCRIPTION
It looks like mac support was added in #69 so I thought maybe this was missed in 5f7b3615. I thought Macs still weren't supported due to this.