### PR TITLE
Add new 'summary' and 'summary_line' output formats

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,2 +1,3 @@
 pub mod output;
 pub mod callgrind;
+pub mod summary;

--- a/src/ui/output.rs
+++ b/src/ui/output.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 use ui::callgrind;
+use ui::summary;
 use core::initialize::StackFrame;
 
 const FLAMEGRAPH_SCRIPT: &'static [u8] = include_bytes!("../../vendor/flamegraph/flamegraph.pl");
@@ -48,6 +49,34 @@ impl Outputter for Callgrind {
 
     fn complete(&mut self, _path: &Path, mut file: File) -> Result<(), Error> {
         self.0.finish();
+        self.0.write(&mut file)?;
+        Ok(())
+    }
+}
+
+pub struct Summary(pub summary::Stats);
+
+impl Outputter for Summary {
+    fn record(&mut self, _file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error> {
+        self.0.add_function_name(stack);
+        Ok(())
+    }
+
+    fn complete(&mut self, _path: &Path, mut file: File) -> Result<(), Error> {
+        self.0.write(&mut file)?;
+        Ok(())
+    }
+}
+
+pub struct SummaryLine(pub summary::Stats);
+
+impl Outputter for SummaryLine {
+    fn record(&mut self, _file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error> {
+        self.0.add_lineno(stack);
+        Ok(())
+    }
+
+    fn complete(&mut self, _path: &Path, mut file: File) -> Result<(), Error> {
         self.0.write(&mut file)?;
         Ok(())
     }

--- a/src/ui/summary.rs
+++ b/src/ui/summary.rs
@@ -1,0 +1,146 @@
+use std::collections::{HashMap, HashSet};
+use std::io;
+
+use core::initialize::StackFrame;
+
+struct Counts {
+    self_: u64,
+    total: u64,
+}
+
+pub struct Stats {
+    counts: HashMap<String, Counts>,
+    total_traces: u32,
+}
+
+
+impl Stats {
+    const HEADER: &'static str = "% self  % total  name";
+
+    pub fn new() -> Stats {
+        Stats { counts: HashMap::new(), total_traces: 0}
+    }
+
+    fn inc_self(&mut self, name: String) {
+        let entry = self.counts.entry(name).or_insert(Counts{self_: 0, total: 0});
+        entry.self_ += 1;
+    }
+
+    fn inc_tot(&mut self, name: String) {
+        let entry = self.counts.entry(name).or_insert(Counts{self_: 0, total: 0});
+        entry.total += 1;
+    }
+
+    fn name_function(frame: &StackFrame) -> String {
+        format!("{} - {}", frame.name, frame.relative_path)
+    }
+
+    fn name_lineno(frame: &StackFrame) -> String {
+        format!("{}", frame)
+    }
+
+    // Aggregate by function name
+    pub fn add_function_name(&mut self, stack: &Vec<StackFrame>) {
+        self.total_traces += 1;
+        self.inc_self(Stats::name_function(&stack[0]));
+        let mut set: HashSet<String> = HashSet::new();
+        for frame in stack {
+            set.insert(Stats::name_function(frame));
+        }
+        for name in set.into_iter() {
+            self.inc_tot(name);
+        }
+    }
+
+    // Aggregate by function name + line number
+    pub fn add_lineno(&mut self, stack: &Vec<StackFrame>) {
+        self.total_traces += 1;
+        self.inc_self(Stats::name_lineno(&stack[0]));
+        let mut set: HashSet<&StackFrame> = HashSet::new();
+        for frame in stack {
+            set.insert(&frame);
+        }
+        for frame in set {
+            self.inc_tot(Stats::name_lineno(frame));
+        }
+    }
+
+    pub fn write(&self, w: &mut io::Write) -> io::Result<()> {
+        let mut sorted: Vec<(u64, u64, &str)> = self.counts.iter().map(|(x,y)| (y.self_, y.total, x.as_ref())).collect();
+        sorted.sort();
+        // TODO: don't print header if stdout is a pipe so the only thing on stdout is the numbers
+        writeln!(w, "{}", Stats::HEADER)?;
+        for &(self_, total, name) in sorted.iter().rev() {
+            writeln!(w, "{:>6.2} {:>8.2}  {}", 100.0 * (self_ as f64) / (self.total_traces as f64), 100.0 * (total as f64) / (self.total_traces as f64), name)?;
+        }
+        println!("{}", Stats::HEADER);
+        for &(self_, total, name) in sorted.iter().rev().take(20) {
+            println!("{:>6.2} {:>8.2}  {}", 100.0 * (self_ as f64) / (self.total_traces as f64), 100.0 * (total as f64) / (self.total_traces as f64), name);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ui::summary::*;
+
+    // Build a test stackframe
+    fn f(i: u32) -> StackFrame {
+        StackFrame {
+            name: format!("func{}", i),
+            relative_path: format!("file{}.rb", i),
+            absolute_path: None,
+            lineno: i,
+        }
+    }
+
+    #[test]
+    fn stats_by_function() {
+        let mut stats = Stats::new();
+
+        stats.add_function_name(&vec![f(1)]);
+        stats.add_function_name(&vec![f(3), f(2), f(1)]);
+        stats.add_function_name(&vec![f(2), f(1)]);
+        stats.add_function_name(&vec![f(3), f(1)]);
+        stats.add_function_name(&vec![f(2), f(3), f(1)]);
+
+        let expected = "% self  % total  name
+ 40.00    60.00  func3 - file3.rb
+ 40.00    60.00  func2 - file2.rb
+ 20.00   100.00  func1 - file1.rb
+";
+
+        let mut buf: Vec<u8> = Vec::new();
+        stats
+            .write(&mut buf)
+            .expect("Callgrind write failed");
+        let actual = String::from_utf8(buf).expect("summary output not utf8");
+        assert_eq!(actual, expected, "Unexpected summary output");
+    }
+
+    #[test]
+    fn stats_by_line_number() {
+        let mut stats = Stats::new();
+
+        stats.add_lineno(&vec![f(1)]);
+        stats.add_lineno(&vec![f(3), f(2), f(1)]);
+        stats.add_lineno(&vec![f(2), f(1)]);
+        stats.add_lineno(&vec![f(3), f(1)]);
+        stats.add_lineno(&vec![f(2), f(3), f(1)]);
+
+        let expected = "% self  % total  name
+ 40.00    60.00  func3 - file3.rb line 3
+ 40.00    60.00  func2 - file2.rb line 2
+ 20.00   100.00  func1 - file1.rb line 1
+";
+
+        let mut buf: Vec<u8> = Vec::new();
+        stats
+            .write(&mut buf)
+            .expect("summary write failed");
+        let actual = String::from_utf8(buf).expect("summary output not utf8");
+        assert_eq!(actual, expected, "Unexpected summary output");
+    }
+
+}


### PR DESCRIPTION
This adds 2 new output formats -- a summary and a summary by line number. The idea here is sometimes you just want to get a quick idea of what your hot spots are and don't want to look at a flamegraph or callgrind output.

**summary format**

```
% self  % total  name
 19.86   100.00  <c function> - unknown
 15.65    15.65  source_range - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rubocop-0.52.1/lib/rubocop/ast/node.rb
 13.04    36.31  block in tokens - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rubocop-0.52.1/lib/rubocop/cop/mixin/surrounding_space.rb
  6.02     6.02  end_pos - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rubocop-0.52.1/lib/rubocop/token.rb
  4.31    60.68  block (2 levels) in on_send - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rubocop-0.52.1/lib/rubocop/cop/commissioner.rb
  3.81     8.22  advance - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/parser-2.4.0.2/lib/parser/lexer.rb
  2.41    10.53  block in each_child_node - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rubocop-0.52.1/lib/rubocop/ast/node.rb
  1.71     3.21  block (2 levels) in <class:Node> - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rubocop-0.52.1/lib/rubocop/ast/node.rb
  1.60     1.71  begin_pos - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rubocop-0.52.1/lib/rubocop/token.rb
```

**summary by line format**

```
% self  % total  name
 41.40   100.00  <c function> - unknown line 0
  3.70     7.20  block in tokens - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rubocop-0.52.1/lib/rubocop/cop/mixin/surrounding_space.rb line 58
  2.60     2.60  source_range - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rubocop-0.52.1/lib/rubocop/ast/node.rb line 259
  2.50     4.30  advance - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/parser-2.4.0.2/lib/parser/lexer.rb line 21701
  2.20    23.60  block (2 levels) in on_send - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rubocop-0.52.1/lib/rubocop/cop/commissioner.rb line 44
  1.80     7.40  block in each_child_node - /home/bork/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rubocop-0.52.1/lib/rubocop/ast/node.rb line 174
```