### PR TITLE
Make different output formats use different extensions

### DIFF
--- a/src/ui/output.rs
+++ b/src/ui/output.rs
@@ -1,10 +1,13 @@
 #[cfg(test)]
 extern crate tempdir;
 
+use chrono::prelude::*;
 use failure::{Error, ResultExt};
-use std::fs::File;
+
+use std;
+use std::fs::{File, DirBuilder};
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use ui::callgrind;
@@ -13,9 +16,45 @@ use core::initialize::StackFrame;
 
 const FLAMEGRAPH_SCRIPT: &'static [u8] = include_bytes!("../../vendor/flamegraph/flamegraph.pl");
 
+pub struct Output {
+    pub file: File,
+    pub prefix: String,
+    pub path: PathBuf,
+    outputter: Box<Outputter>,
+}
+
+impl Output {
+    pub fn new (output_dir: &Path, outputter: Box<Outputter>) -> Result<Output, Error> {
+
+        let filename = random_filename();
+        let prefix = output_dir.join(filename).to_string_lossy().to_string();
+        let path = format!("{}{}", prefix, outputter.extension());
+        let file = File::create(&path).context(format!(
+                "Failed to create output file {}",
+                &path
+                ))?;
+        Ok(Output {
+            outputter: outputter,
+            path: path.into(),
+            prefix,
+            file
+        })
+    }
+
+    pub fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), Error> {
+        self.outputter.record(&mut self.file, stack)
+    }
+
+    pub fn complete(mut self) -> Result<(), Error> {
+        self.outputter.complete(&self.prefix, self.path.as_ref(), self.file)
+    }
+}
+
 pub trait Outputter {
+    // extension of file to pass into `.record`
+    fn extension(&self) -> &'static str;
     fn record(&mut self, file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error>;
-    fn complete(&mut self, path: &Path, file: File) -> Result<(), Error>;
+    fn complete(&mut self, prefix: &str, path: &Path, file: File) -> Result<(), Error>;
 }
 
 // Uses Brendan Gregg's flamegraph.pl script (which we vendor) to visualize stack traces
@@ -31,12 +70,13 @@ impl Outputter for Flamegraph {
         writeln!(file, " {}", 1)?;
         Ok(())
     }
-
-    fn complete(&mut self, path: &Path, file: File) -> Result<(), Error> {
+    fn complete(&mut self, prefix: &str, path: &Path, file: File) -> Result<(), Error> {
         drop(file); // close it!
-        write_flamegraph(path).context("Writing flamegraph failed")?;
+        write_flamegraph(prefix, path).context("Writing flamegraph failed")?;
         Ok(())
     }
+
+    fn extension(&self) -> &'static str { ".raw.txt" }
 }
 
 pub struct Callgrind(pub callgrind::Stats);
@@ -47,11 +87,13 @@ impl Outputter for Callgrind {
         Ok(())
     }
 
-    fn complete(&mut self, _path: &Path, mut file: File) -> Result<(), Error> {
+    fn complete(&mut self, _: &str, _: &Path, mut file: File) -> Result<(), Error> {
         self.0.finish();
         self.0.write(&mut file)?;
         Ok(())
     }
+
+    fn extension(&self) -> &'static str { ".callgrind.txt" }
 }
 
 pub struct Summary(pub summary::Stats);
@@ -62,10 +104,12 @@ impl Outputter for Summary {
         Ok(())
     }
 
-    fn complete(&mut self, _path: &Path, mut file: File) -> Result<(), Error> {
+    fn complete(&mut self, _: &str, _: &Path, mut file: File) -> Result<(), Error> {
         self.0.write(&mut file)?;
         Ok(())
     }
+
+    fn extension(&self) -> &'static str { ".summary.txt" }
 }
 
 pub struct SummaryLine(pub summary::Stats);
@@ -76,10 +120,12 @@ impl Outputter for SummaryLine {
         Ok(())
     }
 
-    fn complete(&mut self, _path: &Path, mut file: File) -> Result<(), Error> {
+    fn complete(&mut self, _: &str, _: &Path, mut file: File) -> Result<(), Error> {
         self.0.write(&mut file)?;
         Ok(())
     }
+    
+    fn extension(&self) -> &'static str { ".summary_by_line.txt" }
 }
 
 #[test]
@@ -94,11 +140,10 @@ fn test_write_flamegraph() {
     tempdir.close().unwrap();
 }
 
-fn write_flamegraph<P: AsRef<Path>>(stacks_filename: P) -> Result<(), Error> {
-    let stacks_filename = stacks_filename.as_ref();
-    let svg_filename = stacks_filename.with_extension("svg");
+fn write_flamegraph(prefix: &str, stacks_filename: &Path) -> Result<(), Error> {
+    let svg_filename = format!("{}.flamegraph.svg", prefix);
     let output_svg = File::create(&svg_filename)?;
-    eprintln!("Writing flamegraph to {}", svg_filename.display());
+    eprintln!("Writing flamegraph to {}", svg_filename);
     let mut child = Command::new("perl")
         .arg("-")
         .arg("--inverted") // icicle graphs are easier to read
@@ -115,4 +160,31 @@ fn write_flamegraph<P: AsRef<Path>>(stacks_filename: P) -> Result<(), Error> {
     }
     child.wait()?;
     Ok(())
+}
+
+#[test]
+fn test_random_filename() {
+    assert!(
+        random_filename()
+            .to_string_lossy()
+            .contains("rbspy-")
+    );
+}
+
+fn random_filename() -> String {
+    use rand::{self, Rng};
+    let s = rand::thread_rng()
+        .gen_ascii_chars()
+        .take(10)
+        .collect::<String>();
+    format!("{}-{}-{}", "rbspy", Utc::now().format("%Y-%m-%d"), s)
+}
+
+pub fn create_output_dir(dir: Option<&str>) -> Result<PathBuf, Error> {
+    let dirname = match dir {
+        Some(d) => d.into(),
+        None => Path::new(&std::env::var("HOME")?).join(".cache/rbspy/records"),
+    };
+    DirBuilder::new().recursive(true).create(&dirname)?;
+    Ok(dirname)
 }


### PR DESCRIPTION
This makes different output formats use different extensions. The idea is that callgrind should write `.callgrind.txt`, flamegraphs `.flamegraph.svg`, summaries `.summary.txt`, etc. This also changes the `--file` command line parameter to `--dir`.

So instead of telling rbspy which file you want to write to, instead you give it a directory and it will create that directory and some number of files inside that directory.

As part of this I refactored most of the output file logic / data into an `Output` struct. I think this is easier to understand but I'm not sure.

