### PR TITLE
Aggregate flamegraph samples while rbspy is running

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ nix = "0.10.0"
 libc = "0.2.34"
 rbspy-ruby-structs = { path = "ruby-structs", version="0.1.0" }
 term_size = "0.3"
+tempdir = "0.3"
 
 [target.'cfg(target_os="macos")'.dependencies]
 mach = "0.1.2"

--- a/src/ui/flamegraph.rs
+++ b/src/ui/flamegraph.rs
@@ -1,0 +1,115 @@
+use std::collections::HashMap;
+use std::io;
+use std::io::Write;
+use std::fs::File;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use core::initialize::StackFrame;
+
+use failure::{Error, ResultExt};
+use tempdir;
+
+const FLAMEGRAPH_SCRIPT: &'static [u8] = include_bytes!("../../vendor/flamegraph/flamegraph.pl");
+
+pub struct Stats {
+    pub counts: HashMap<Vec<u8>, usize>,
+}
+
+impl Stats {
+    pub fn new() -> Stats {
+        Stats {
+            counts: HashMap::new(),
+        }
+    }
+
+    pub fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), io::Error> {
+        let mut buf = vec![];
+        for t in stack.iter().rev() {
+            write!(&mut buf, "{}", t)?;
+            write!(&mut buf, ";")?;
+        }
+        let count = self.counts.entry(buf).or_insert(0);
+        *count += 1;
+        Ok(())
+    }
+
+    pub fn write(&self, w: File) -> Result<(), Error> {
+        let tempdir = tempdir::TempDir::new("flamegraph").unwrap();
+        let stacks_file = tempdir.path().join("stacks.txt");
+        let mut file = File::create(&stacks_file).expect("couldn't create file");
+        for (k, v) in self.counts.iter() {
+            file.write(&k)?;
+            writeln!(file, " {}", v)?;
+        }
+        write_flamegraph(stacks_file, w)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ui::flamegraph::*;
+
+    // Build a test stackframe
+    fn f(i: u32) -> StackFrame {
+        StackFrame {
+            name: format!("func{}", i),
+            relative_path: format!("file{}.rb", i),
+            absolute_path: None,
+            lineno: i,
+        }
+    }
+
+    fn assert_contains(counts: &HashMap<Vec<u8>, usize>, s: &str, val: usize) {
+        assert_eq!(counts.get(&s.to_string().into_bytes()), Some(&val));
+    }
+
+    #[test]
+    fn test_stats() {
+        let mut stats = Stats::new();
+
+        stats.record(&vec![f(1)]);
+        stats.record(&vec![f(2), f(1)]);
+        stats.record(&vec![f(2), f(1)]);
+        stats.record(&vec![f(2), f(3), f(1)]);
+        stats.record(&vec![f(2), f(3), f(1)]);
+        stats.record(&vec![f(2), f(3), f(1)]);
+
+        let counts = &stats.counts;
+        assert_contains(counts, "func1 - file1.rb line 1;", 1);
+        assert_contains(counts, "func1 - file1.rb line 1;func3 - file3.rb line 3;func2 - file2.rb line 2;", 3);
+        assert_contains(counts, "func1 - file1.rb line 1;func2 - file2.rb line 2;", 2);
+    }
+}
+
+#[test]
+fn test_write_flamegraph() {
+    let tempdir = tempdir::TempDir::new("flamegraph").unwrap();
+    let stacks_file = tempdir.path().join("stacks.txt");
+    let mut file = File::create(&stacks_file).expect("couldn't create file");
+    for _ in 1..10 {
+        file.write(b"a;a;a;a 1").unwrap();
+    }
+    let target = File::create(tempdir.path().join("graph.svg")).expect("couldn't create file");
+    write_flamegraph(stacks_file, target).expect("Couldn't write flamegraph");
+    tempdir.close().unwrap();
+}
+
+fn write_flamegraph<P: AsRef<Path>>(source: P, target: File) -> Result<(), Error> {
+    let mut child = Command::new("perl")
+        .arg("-")
+        .arg("--inverted") // icicle graphs are easier to read
+        .arg("--minwidth").arg("2") // min width 2 pixels saves on disk space
+        .arg(source.as_ref())
+        .stdin(Stdio::piped()) // pipe in the flamegraph.pl script to stdin
+        .stdout(target)
+        .spawn()
+        .context("Couldn't execute perl")?;
+    // TODO(nll): Remove this silliness after non-lexical lifetimes land.
+    {
+        let stdin = child.stdin.as_mut().expect("failed to write to stdin");
+        stdin.write_all(FLAMEGRAPH_SCRIPT)?;
+    }
+    child.wait()?;
+    Ok(())
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
 pub mod output;
 pub mod callgrind;
 pub mod summary;
+pub mod flamegraph;

--- a/src/ui/output.rs
+++ b/src/ui/output.rs
@@ -1,40 +1,30 @@
 #[cfg(test)]
 extern crate tempdir;
 
-use failure::{Error, ResultExt};
+use failure::Error;
 use std::fs::File;
-use std::io::Write;
-use std::path::Path;
-use std::process::{Command, Stdio};
 
 use ui::callgrind;
 use ui::summary;
+use ui::flamegraph;
 use core::initialize::StackFrame;
 
-const FLAMEGRAPH_SCRIPT: &'static [u8] = include_bytes!("../../vendor/flamegraph/flamegraph.pl");
-
 pub trait Outputter {
-    fn record(&mut self, file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error>;
-    fn complete(&mut self, path: &Path, file: File) -> Result<(), Error>;
+    fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), Error>;
+    fn complete(&mut self, file: File) -> Result<(), Error>;
 }
 
 // Uses Brendan Gregg's flamegraph.pl script (which we vendor) to visualize stack traces
-pub struct Flamegraph;
+pub struct Flamegraph(pub flamegraph::Stats);
 
 impl Outputter for Flamegraph {
-    fn record(&mut self, file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error> {
-        // This is the input file format that flamegraph.pl expects: 'a; b; c 1'
-        for t in stack.iter().rev() {
-            write!(file, "{}", t)?;
-            write!(file, ";")?;
-        }
-        writeln!(file, " {}", 1)?;
+    fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), Error> {
+        self.0.record(stack)?;
         Ok(())
     }
 
-    fn complete(&mut self, path: &Path, file: File) -> Result<(), Error> {
-        drop(file); // close it!
-        write_flamegraph(path).context("Writing flamegraph failed")?;
+    fn complete(&mut self, file: File) -> Result<(), Error> {
+        self.0.write(file)?;
         Ok(())
     }
 }
@@ -42,12 +32,12 @@ impl Outputter for Flamegraph {
 pub struct Callgrind(pub callgrind::Stats);
 
 impl Outputter for Callgrind {
-    fn record(&mut self, _file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error> {
+    fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), Error> {
         self.0.add(stack);
         Ok(())
     }
 
-    fn complete(&mut self, _path: &Path, mut file: File) -> Result<(), Error> {
+    fn complete(&mut self, mut file: File) -> Result<(), Error> {
         self.0.finish();
         self.0.write(&mut file)?;
         Ok(())
@@ -57,12 +47,12 @@ impl Outputter for Callgrind {
 pub struct Summary(pub summary::Stats);
 
 impl Outputter for Summary {
-    fn record(&mut self, _file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error> {
+    fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), Error> {
         self.0.add_function_name(stack);
         Ok(())
     }
 
-    fn complete(&mut self, _path: &Path, mut file: File) -> Result<(), Error> {
+    fn complete(&mut self, mut file: File) -> Result<(), Error> {
         self.0.write(&mut file)?;
         Ok(())
     }
@@ -71,48 +61,13 @@ impl Outputter for Summary {
 pub struct SummaryLine(pub summary::Stats);
 
 impl Outputter for SummaryLine {
-    fn record(&mut self, _file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error> {
+    fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), Error> {
         self.0.add_lineno(stack);
         Ok(())
     }
 
-    fn complete(&mut self, _path: &Path, mut file: File) -> Result<(), Error> {
+    fn complete(&mut self, mut file: File) -> Result<(), Error> {
         self.0.write(&mut file)?;
         Ok(())
     }
-}
-
-#[test]
-fn test_write_flamegraph() {
-    let tempdir = tempdir::TempDir::new("flamegraph").unwrap();
-    let stacks_file = tempdir.path().join("stacks.txt");
-    let mut file = File::create(&stacks_file).expect("couldn't create file");
-    for _ in 1..10 {
-        file.write(b"a;a;a;a 1").unwrap();
-    }
-    write_flamegraph(stacks_file.to_str().unwrap()).expect("Couldn't write flamegraph");
-    tempdir.close().unwrap();
-}
-
-fn write_flamegraph<P: AsRef<Path>>(stacks_filename: P) -> Result<(), Error> {
-    let stacks_filename = stacks_filename.as_ref();
-    let svg_filename = stacks_filename.with_extension("svg");
-    let output_svg = File::create(&svg_filename)?;
-    eprintln!("Writing flamegraph to {}", svg_filename.display());
-    let mut child = Command::new("perl")
-        .arg("-")
-        .arg("--inverted") // icicle graphs are easier to read
-        .arg("--minwidth").arg("2") // min width 2 pixels saves on disk space
-        .arg(stacks_filename)
-        .stdin(Stdio::piped()) // pipe in the flamegraph.pl script to stdin
-        .stdout(output_svg)
-        .spawn()
-        .context("Couldn't execute perl")?;
-    // TODO(nll): Remove this silliness after non-lexical lifetimes land.
-    {
-        let stdin = child.stdin.as_mut().expect("failed to write to stdin");
-        stdin.write_all(FLAMEGRAPH_SCRIPT)?;
-    }
-    child.wait()?;
-    Ok(())
 }


### PR DESCRIPTION
This aggregates stack samples in memory instead of writing them to disk and then making the perl script do the aggregation. motivations:

* reduces writes to disk
* means that the flamegraph output isn't a special snowflake, which means we can have a cleaner `Outputter` trait

I'm most excited about reason 2 right now because I want rbspy to *always* record raw data (not just when it's writing a flamegraph), and this will make it easier to add the "always record raw data" feature.