### PR TITLE
Add new `rbspy report` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "elf"
 version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +183,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +228,11 @@ dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
@@ -424,6 +443,7 @@ dependencies = [
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -438,6 +458,9 @@ dependencies = [
  "read-process-memory 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -553,6 +576,41 @@ dependencies = [
 name = "semver"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "strsim"
@@ -755,17 +813,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4151c5790817c7d21bbdc6c3530811f798172915f93258244948b93ba19604a6"
 "checksum ctrlc 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "653abc99aa905f693d89df4797fadc08085baee379db92be9f2496cefe8a6f2c"
+"checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum elf 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4841de15dbe0e49b9b62a417589299e3be0d557e0900d36acb87e6dae47197f5"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1e2b2decb0484e15560df3210cf0d78654bb0864b2c138977c07e377a1bae0e2"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
+"checksum flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fac2277e84e5e858483756647a9d0aa8d9a2b7cba517fd84325a0aaa69a0909"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum goblin 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2a5fea7ad351be7398e08003ea92a16bbba9a23c2a0c95d4e37d178276508217"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
@@ -804,6 +865,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum scroll 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b13864e1e0b3ed661d7206d512b8d1c4970f7fd9de23ae4e9b4331f0c25559e8"
 "checksum scroll_derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a67086db2a44e94311fc4c02ec3f4751bda0fca9d87fd4e1bfe1cef55e9411d"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
+"checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"
+"checksum serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ba7591cfe93755e89eeecdbcc668885624829b020050e6aec99c2a03bd3fd0"
+"checksum serde_derive_internals 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e03f1c9530c3fb0a0a5c9b826bdd9246a5921ae995d75f512ac917fc4dd55b5"
+"checksum serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9db7266c7d63a4c4b7fe8719656ccdd51acf1bed6124b174f933b009fb10bcb"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,13 @@ rand = "0.4"
 read-process-memory = "0.1.0"
 failure = "0.1.1"
 failure_derive = "0.1.1"
+flate2 = "1"
 nix = "0.10.0"
 libc = "0.2.34"
 rbspy-ruby-structs = { path = "ruby-structs", version="0.1.0" }
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
 term_size = "0.3"
 tempdir = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,13 @@ sudo rbspy snapshot --pid $PID
 
 ### Record
 
-Record records stack traces from your process and generates a flamegraph.
+Record records stack traces from your process and saves them to disk.
+
+`rbspy record` will save 2 files: a gzipped raw data file, and a visualization (by default a flamegraph, you
+can configure the visualization format with `--format`). The raw data file contains every stack
+trace that `rbspy` recorded, so that you can generate other visualizations later if you want. By
+default, rbspy saves both files to `~/.cache/rbspy/records`, but you can customize where those are
+stored with `--file` and `--raw-file`.
 
 This is useful when you want to know what functions your program is spending most of its time in.
 
@@ -77,11 +83,40 @@ you're user `bork` and run `sudo rbspy record ruby script.rb`. You can disable t
 
 #### Optional Arguments
 
-These work regardless of how you started the recording.
+These work regardless of how you started the recording. 
 
- * `--file`: Specifies where rbspy will save data. By default, rbspy saves to `~/.cache/rbspy/records`.
  * `--rate`: Specifies the frequency of that stack traces are recorded. The interval is determined by `1000/rate`. The default rate is 100hz.
  * `--duration`: Specifies how long to run before stopping rbspy. This conficts with running a subcommand (`rbspy record ruby myprogram.rb`).
+ * `--format`: Specifies what format to use to report profiling data. The options are:
+   * `flamegraph`: generates a flamegraph SVG that you can view in a browser
+   * `callgrind`: generates a callgrind-formatted file that you can view with a tool like
+     `kcachegrind`.
+   * `summary`: aggregates % self and % total times by function. Useful to get a basic overview
+   * `summary_by_line`: aggregates % self and % total times by line number. Especially useful when
+      there's 1 line in your program which is taking up all the time.
+ * `--file`: Specifies where rbspy will save formatted output. 
+ * `--raw-file`: Specifies where rbspy will save formatted data. Use a gz extension because it will be gzipped.
+
+## Reporting
+
+If you have a raw rbspy data file that you've previously recorded, you can use `rbspy report` to
+generate different kinds of visualizations from it (the flamegraph/callgrind/summary formats, as
+documented above). This is useful because you can record raw data from a program and then decide how
+you want to visualize it afterwards.
+
+For example, here's what recording a simple program and then generating a summary report looks like:
+
+```
+$ sudo rbspy record --raw-file raw.gz ruby ci/ruby-programs/short_program.rb
+$ rbspy report -f summary -i raw.gz -o summary.txt
+$ cat summary.txt
+% self  % total  name
+100.00   100.00  <c function> - unknown
+  0.00   100.00  ccc - ci/ruby-programs/short_program.rb
+  0.00   100.00  bbb - ci/ruby-programs/short_program.rb
+  0.00   100.00  aaa - ci/ruby-programs/short_program.rb
+  0.00   100.00  <main> - ci/ruby-programs/short_program.rb
+```
 
 ## What's a flamegraph?
 

--- a/src/core/initialize.rs
+++ b/src/core/initialize.rs
@@ -44,7 +44,7 @@ pub fn initialize(pid: pid_t) -> Result<StackTraceGetter, Error> {
     })
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize)]
 pub struct StackFrame {
     pub name: String,
     pub relative_path: String,

--- a/src/core/initialize.rs
+++ b/src/core/initialize.rs
@@ -44,7 +44,7 @@ pub fn initialize(pid: pid_t) -> Result<StackTraceGetter, Error> {
     })
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct StackFrame {
     pub name: String,
     pub relative_path: String,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,53 @@
+/// Storage formats, and io functions for rbspy's internal raw storage format.
+///
+/// rbspy has a versioned "raw" storage format. The versioning info is stored,
+/// along with a "magic number" at the start of the file. The magic number plus
+/// version are the first 8 bytes of the file, and are represented as
+///
+///     b"rbspyXY\n"
+///
+/// Here, `XY` is [Julia: your choice of...]
+///   - decimal number in [0-99]
+///   - hex number in [0-255]
+///   - base32 number in [0-1023]
+///   - base64 number in [0-4096]
+///
+/// The use of b'\n' as a terminator effectively reserves a byte, and provides
+/// flexibility to go to a different version encoding scheme if this format
+/// changes _way_ to much.
+extern crate flate2;
+
+use std::io;
+use std::io::prelude::*;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use core::initialize::StackFrame;
+
+use self::flate2::write::GzEncoder;
+use self::flate2::Compression;
+use failure::Error;
+use serde_json;
+
+pub struct Store {
+    encoder: GzEncoder<File>,
+}
+
+impl Store {
+    pub fn new(out_path: &Path) -> Result<Store, io::Error> {
+        let file = File::create(out_path)?;
+        let mut encoder = GzEncoder::new(file, Compression::default());
+        encoder.write("rbspy00\n".as_bytes())?;
+        Ok(Store { encoder })
+    }
+
+    pub fn write(&mut self, trace: &Vec<StackFrame>) -> Result<(), Error> {
+        let json = serde_json::to_string(trace)?;
+        self.encoder.write(json.as_bytes())?;
+        Ok(())
+    }
+
+    pub fn complete(self) {
+        drop(self.encoder)
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,11 +6,7 @@
 ///
 ///     b"rbspyXY\n"
 ///
-/// Here, `XY` is [Julia: your choice of...]
-///   - decimal number in [0-99]
-///   - hex number in [0-255]
-///   - base32 number in [0-1023]
-///   - base64 number in [0-4096]
+/// Here, `XY` is a decimal number in [0-99]
 ///
 /// The use of b'\n' as a terminator effectively reserves a byte, and provides
 /// flexibility to go to a different version encoding scheme if this format
@@ -20,34 +16,113 @@ extern crate flate2;
 use std::io;
 use std::io::prelude::*;
 use std::fs::File;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use core::initialize::StackFrame;
 
-use self::flate2::write::GzEncoder;
 use self::flate2::Compression;
 use failure::Error;
 use serde_json;
 
+mod v0;
+
 pub struct Store {
-    encoder: GzEncoder<File>,
+    encoder: flate2::write::GzEncoder<File>,
 }
 
 impl Store {
     pub fn new(out_path: &Path) -> Result<Store, io::Error> {
         let file = File::create(out_path)?;
-        let mut encoder = GzEncoder::new(file, Compression::default());
+        let mut encoder = flate2::write::GzEncoder::new(file, Compression::default());
         encoder.write("rbspy00\n".as_bytes())?;
         Ok(Store { encoder })
     }
 
     pub fn write(&mut self, trace: &Vec<StackFrame>) -> Result<(), Error> {
         let json = serde_json::to_string(trace)?;
-        self.encoder.write(json.as_bytes())?;
+        writeln!(&mut self.encoder, "{}", json)?;
         Ok(())
     }
 
     pub fn complete(self) {
         drop(self.encoder)
+    }
+}
+
+#[derive(Clone, Debug, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct Version(u64);
+
+// Write impls like this for every storage version (no need for the internal
+// one, since `impl<T> From<T> for T` exists.
+//
+// impl From<v7::Data> for JuliaData {
+//     fn from(d: v7::Data) -> JuliaData {
+//         unimplemented!();
+//     }
+// }
+
+
+impl ::std::fmt::Display for Version {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Version {
+    /// Parse bytes to a version.
+    ///
+    /// # Errors
+    /// Fails with `StorageError::Invalid` if the version tag is in an unknown
+    /// format.
+    fn try_from(b: &[u8]) -> Result<Version, StorageError> {
+        if &b[0..3] == "00\n".as_bytes() {
+            Ok(Version(0))
+        } else {
+            Err(StorageError::Invalid)
+        }
+    }
+}
+
+#[derive(Fail, Debug)]
+pub(crate) enum StorageError {
+    /// The file doesn't begin with the magic tag `rbspy` + version number.
+    #[fail(display = "Invalid rbpsy file")]
+    Invalid,
+    /// The version of the rbspy file can't be handled by this version of rbspy.
+    #[fail(display = "Cannot handle rbspy format {}", _0)]
+    UnknownVersion(Version),
+    /// An IO error occurred.
+    #[fail(display = "IO error {:?}", _0)]
+    Io(#[cause] io::Error),
+}
+
+/// Types that can be deserialized from an `io::Read` into something convertible
+/// to the current internal form.
+pub(crate) trait Storage: Into<v0::Data> {
+    fn from_reader<R: Read>(r: R) -> Result<Self, Error>;
+    fn version() -> Version;
+}
+
+fn read_version(r: &mut Read) -> Result<Version, StorageError> {
+    let mut buf = [0u8; 8];
+    // TODO: I don't know how to failure good, so this doesn't work.
+    r.read(&mut buf).map_err(StorageError::Io)?;
+    match &buf[..5] {
+        b"rbspy" => Ok(Version::try_from(&buf[5..])?),
+        _ => Err(StorageError::Invalid),
+    }
+}
+
+pub(crate) fn from_reader<R: Read>(r: R) -> Result<Vec<Vec<StackFrame>>, Error> {
+    // This will read 8 bytes, leaving the reader's cursor at the start of the
+    // "real" data.
+    let mut reader = flate2::read::GzDecoder::new(r);
+    let version = read_version(&mut reader)?;
+    match version {
+        Version(0) => {
+            let intermediate = v0::Data::from_reader(reader)?;
+            Ok(intermediate.into())
+        }
+        v => Err(StorageError::UnknownVersion(v).into()),
     }
 }

--- a/src/storage/v0.rs
+++ b/src/storage/v0.rs
@@ -1,0 +1,29 @@
+use std::io::prelude::*;
+use std::io::BufReader;
+use core::initialize::StackFrame;
+
+use failure::Error;
+use serde_json;
+
+use super::*;
+
+// The first version is just your internal representation.
+pub(crate) type Data = Vec<Vec<StackFrame>>;
+
+impl Storage for Data {
+    fn from_reader<R: Read>(r: R) -> Result<Data, Error> {
+        let reader = BufReader::new(r);
+        let mut result = Vec::new();
+        for line in reader.lines() {
+            let trace = serde_json::from_str(&line?)?;
+            result.push(trace);
+        }
+        Ok(result)
+    }
+    fn version() -> Version {
+        // The "version" for the internal representation is bumped every time
+        // you make a change to it, copying the old struct into a new file at
+        // `src/vblah`.
+        Version(0)
+    }
+}


### PR DESCRIPTION
This pull request:

a) makes `rbspy record` save raw data to disk (the raw data format here is newline-separated JSON, which is then gzipped). I don't really see any reason to use a fancier format, since gzipping doesn't take that much time and reduces the filesize of the JSON by about 10x. The raw data format is versioned (h/t @kamalmarhubi) so that we can easily maintain backwards compatibility if/when we change the raw data format.
b) adds a new subcommand called `report` which lets you create new visualizations from saved recorded data!

I'm excited about the new `report` subcommand because it means that if you decide after the fact that you want to visualize your data a different way, you can!

would love any code review / comments on the design!

I've updated the README to explain the new `report` feature.