### PR TITLE
Add stack trace struct containing PID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,11 +245,6 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lazy_static"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -454,7 +449,7 @@ dependencies = [
  "object 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rbspy-ruby-structs 0.1.0",
- "rbspy-testdata 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rbspy-testdata 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "read-process-memory 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -471,14 +466,13 @@ version = "0.1.0"
 
 [[package]]
 name = "rbspy-testdata"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "elf 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "read-process-memory 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -828,7 +822,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
 "checksum libproc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb1b082528c20123beb4f8f4028c16041fa95d3b07998dbc192a9f8912b5df1"
@@ -852,7 +845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
-"checksum rbspy-testdata 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "de560d75a16ac4f974a3c6621c06bcf1fb1e505ee06e4f9705cf8b4ab975408b"
+"checksum rbspy-testdata 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5431610059dcec75c1cd300487bc7f25f0086476e23f80c42e23fc4bb3ac650c"
 "checksum read-process-memory 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "950b829b2477880c74aaed706d681bc8d50d4e2b15b5e4d98ed33d5d4f93712e"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ object = "0.1.0"
 
 [dev-dependencies]
 byteorder = "0.5"
-rbspy-testdata = "0.1.1"
+rbspy-testdata = "0.1.2"
 tempdir = "0.3.4"
 
 [build-dependencies]

--- a/src/core/initialize.rs
+++ b/src/core/initialize.rs
@@ -28,13 +28,13 @@ use std;
  *   * Find the right stack trace function for the Ruby version we found
  *   * Package all that up into a struct that the user can use to get stack traces.
  */
-pub fn initialize(pid: pid_t) -> Result<StackTraceGetter, Error> {
+pub fn initialize(pid: pid_t) -> Result<StackTraceGetter<ProcessHandle>, Error> {
     let version = get_ruby_version_retry(pid).context("Couldn't determine Ruby version")?;
     let is_maybe_thread = is_maybe_thread_function(&version);
 
     debug!("version: {}", version);
     Ok(StackTraceGetter {
-        process_handle: pid.try_into_process_handle()?,
+        process: Process{pid: Some(pid), source: pid.try_into_process_handle()?},
         current_thread_addr_location: address_finder::current_thread_address(
             pid,
             &version,
@@ -76,12 +76,24 @@ impl PartialOrd for StackFrame {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct StackTrace {
+    pub trace: Vec<StackFrame>,
+    pub pid: Option<pid_t>,
+}
+
+impl StackTrace {
+    pub fn iter(&self) ->  std::slice::Iter<StackFrame> {
+        self.trace.iter()
+    }
+}
+
 // Use a StackTraceGetter to get stack traces
-pub struct StackTraceGetter {
-    process_handle: ProcessHandle,
+pub struct StackTraceGetter<T> where T: CopyAddress {
+    process: Process<T>,
     current_thread_addr_location: usize,
     stack_trace_function:
-        Box<Fn(usize, &ProcessHandle) -> Result<Vec<StackFrame>, MemoryCopyError>>,
+        Box<Fn(usize, &Process<T>) -> Result<StackTrace, MemoryCopyError>>,
 }
 
 impl fmt::Display for StackFrame {
@@ -90,14 +102,19 @@ impl fmt::Display for StackFrame {
     }
 }
 
-impl StackTraceGetter {
-    pub fn get_trace(&self) -> Result<Vec<StackFrame>, MemoryCopyError> {
+impl<T> StackTraceGetter<T> where T: CopyAddress {
+    pub fn get_trace(&self) -> Result<StackTrace, MemoryCopyError> {
         let stack_trace_function = &self.stack_trace_function;
         stack_trace_function(
             self.current_thread_addr_location,
-            &self.process_handle,
+            &self.process,
         )
     }
+}
+
+pub struct Process<T> where T: CopyAddress {
+    pub pid: Option<pid_t>,
+    pub source: T,
 }
 
 // Everything below here is private
@@ -276,7 +293,7 @@ where
 
 fn get_stack_trace_function<T: 'static>(
     version: &str,
-) -> Box<Fn(usize, &T) -> Result<Vec<StackFrame>, copy::MemoryCopyError>>
+) -> Box<Fn(usize, &Process<T>) -> Result<StackTrace, copy::MemoryCopyError>>
 where
     T: CopyAddress,
 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,7 +309,7 @@ fn record(
             }
             Ok(ref ok_trace) => {
                 out.record(ok_trace)?;
-                summary_out.add_function_name(ok_trace);
+                summary_out.add_function_name(&ok_trace.trace);
                 raw_store.write(ok_trace)?;
             }
             Err(x) => {
@@ -352,7 +352,7 @@ fn record(
 
 fn report(format: OutputFormat, input: PathBuf, output: PathBuf) -> Result<(), Error>{
     let input_file = File::open(input)?;
-    let stuff = storage::from_reader(input_file)?;
+    let stuff = storage::from_reader(input_file)?.0;
     let mut outputter = format.outputter();
     for trace in stuff {
         outputter.record(&trace)?;

--- a/src/storage/v0.rs
+++ b/src/storage/v0.rs
@@ -1,29 +1,38 @@
 use std::io::prelude::*;
 use std::io::BufReader;
-use core::initialize::StackFrame;
+use core::initialize::{StackTrace, StackFrame};
 
 use failure::Error;
 use serde_json;
 
 use super::*;
 
-// The first version is just your internal representation.
-pub(crate) type Data = Vec<Vec<StackFrame>>;
+pub(crate) struct Data(Vec<Vec<StackFrame>>);
 
 impl Storage for Data {
     fn from_reader<R: Read>(r: R) -> Result<Data, Error> {
         let reader = BufReader::new(r);
         let mut result = Vec::new();
         for line in reader.lines() {
-            let trace = serde_json::from_str(&line?)?;
+            let trace: Vec<StackFrame> = serde_json::from_str(&line?)?;
             result.push(trace);
         }
-        Ok(result)
+        Ok(Data(result))
     }
     fn version() -> Version {
-        // The "version" for the internal representation is bumped every time
-        // you make a change to it, copying the old struct into a new file at
-        // `src/vblah`.
         Version(0)
+    }
+}
+
+impl From<Data> for v1::Data {
+    fn from(d: Data) -> v1::Data {
+        let x: Vec<StackTrace> = d.0.into_iter().map(|x| x.into()).collect();
+        v1::Data(x)
+    }
+}
+
+impl From<Vec<StackFrame>> for StackTrace {
+    fn from(trace: Vec<StackFrame>) -> StackTrace {
+        StackTrace{pid: None, trace}
     }
 }

--- a/src/storage/v1.rs
+++ b/src/storage/v1.rs
@@ -1,0 +1,25 @@
+use std::io::prelude::*;
+use std::io::BufReader;
+use core::initialize::StackTrace;
+
+use failure::Error;
+use serde_json;
+
+use super::*;
+
+pub(crate) struct Data(pub Vec<StackTrace>);
+
+impl Storage for Data {
+    fn from_reader<R: Read>(r: R) -> Result<Data, Error> {
+        let reader = BufReader::new(r);
+        let mut result = Vec::new();
+        for line in reader.lines() {
+            let trace: StackTrace = serde_json::from_str(&line?)?;
+            result.push(trace);
+        }
+        Ok(Data(result))
+    }
+    fn version() -> Version {
+        Version(1)
+    }
+}

--- a/src/ui/output.rs
+++ b/src/ui/output.rs
@@ -7,10 +7,10 @@ use std::fs::File;
 use ui::callgrind;
 use ui::summary;
 use ui::flamegraph;
-use core::initialize::StackFrame;
+use core::initialize::StackTrace;
 
 pub trait Outputter {
-    fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), Error>;
+    fn record(&mut self, stack: &StackTrace) -> Result<(), Error>;
     fn complete(&mut self, file: File) -> Result<(), Error>;
 }
 
@@ -18,8 +18,8 @@ pub trait Outputter {
 pub struct Flamegraph(pub flamegraph::Stats);
 
 impl Outputter for Flamegraph {
-    fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), Error> {
-        self.0.record(stack)?;
+    fn record(&mut self, stack: &StackTrace) -> Result<(), Error> {
+        self.0.record(&stack.trace)?;
         Ok(())
     }
 
@@ -32,8 +32,8 @@ impl Outputter for Flamegraph {
 pub struct Callgrind(pub callgrind::Stats);
 
 impl Outputter for Callgrind {
-    fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), Error> {
-        self.0.add(stack);
+    fn record(&mut self, stack: &StackTrace) -> Result<(), Error> {
+        self.0.add(&stack.trace);
         Ok(())
     }
 
@@ -47,8 +47,8 @@ impl Outputter for Callgrind {
 pub struct Summary(pub summary::Stats);
 
 impl Outputter for Summary {
-    fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), Error> {
-        self.0.add_function_name(stack);
+    fn record(&mut self, stack: &StackTrace) -> Result<(), Error> {
+        self.0.add_function_name(&stack.trace);
         Ok(())
     }
 
@@ -61,8 +61,8 @@ impl Outputter for Summary {
 pub struct SummaryLine(pub summary::Stats);
 
 impl Outputter for SummaryLine {
-    fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), Error> {
-        self.0.add_lineno(stack);
+    fn record(&mut self, stack: &StackTrace) -> Result<(), Error> {
+        self.0.add_lineno(&stack.trace);
         Ok(())
     }
 


### PR DESCRIPTION
This updates the data storage format for rbspy to include a PID for each stack trace. The idea here is that sometimes we'll sample stack traces from multiple processes, so it's good to include a PID for each stack trace. This is to support the subprocess profiling work by @liaden.