### PR TITLE
Add --subprocesses flag to rbspy record

### DIFF
--- a/ci/docker-tests.sh
+++ b/ci/docker-tests.sh
@@ -2,8 +2,7 @@ set -eux
 rm -rf /tmp/artifacts
 mkdir /tmp/artifacts
 cp target/$TARGET/debug/rbspy /tmp/artifacts
-cp ci/ruby-programs//short_program.rb /tmp/artifacts
-cp ci/ruby-programs//infinite.rb /tmp/artifacts
+cp ci/ruby-programs/* /tmp/artifacts
 
 rm -f /tmp/output
 touch /tmp/output
@@ -22,6 +21,9 @@ do
    docker build -t rb-stacktrace-$distro -f ./ci/docker/Dockerfile.$distro  ./ci/docker/ >> /tmp/output 2>&1
    echo -n "${distro}... "
    docker run -v=/tmp/artifacts:/stuff rb-stacktrace-$distro env RUST_BACKTRACE=1 /stuff/rbspy record --file /tmp/stacks.txt /usr/bin/ruby /stuff/short_program.rb
+
+   echo -n "subprocess identification"
+   docker run -v=/tmp/artifacts:/stuff rb-stacktrace-$distro env RUST_BACKTRACE=1 /stuff/rbspy record --subprocesses /usr/bin/ruby /stuff/ruby_forks.rb
 done
 
 echo "=================="

--- a/ci/ruby-programs/ruby_forks.rb
+++ b/ci/ruby-programs/ruby_forks.rb
@@ -1,0 +1,11 @@
+SLEEP_TIME = 2
+
+pid1 = fork do
+  pid1_1 = fork { sleep SLEEP_TIME }
+
+  sleep SLEEP_TIME
+end
+
+pid2 = fork { sleep SLEEP_TIME }
+
+sleep SLEEP_TIME

--- a/src/core/initialize.rs
+++ b/src/core/initialize.rs
@@ -155,7 +155,7 @@ fn test_get_disallowed_process() {
 #[test]
 #[cfg(target_os = "linux")]
 fn test_current_thread_address() {
-    let mut process = std::process::Command::new("/usr/bin/ruby").spawn().unwrap();
+    let mut process = std::process::Command::new("/usr/bin/ruby").arg("./ci/ruby-programs/infinite.rb").spawn().unwrap();
     let pid = process.id() as pid_t;
     let version = get_ruby_version_retry(pid).expect("version should exist");
     let is_maybe_thread = is_maybe_thread_function(&version);

--- a/src/ui/descendents.rs
+++ b/src/ui/descendents.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+use std::fs::read_dir;
+use std::fs::File;
+use std::io::Read;
+
+use failure::Error;
+use libc::pid_t;
+
+pub fn descendents_of(parent_pid: pid_t) -> Result<Vec<pid_t>, Error> {
+    let parents_to_children = map_parents_to_children()?;
+    get_descendents(parent_pid, parents_to_children)
+}
+
+fn get_descendents(
+    parent_pid: pid_t,
+    parents_to_children: HashMap<pid_t, Vec<pid_t>>,
+) -> Result<Vec<pid_t>, Error> {
+    let mut result = Vec::<pid_t>::new();
+    let mut queue = Vec::<pid_t>::new();
+    queue.push(parent_pid);
+
+    loop {
+        match queue.pop() {
+            None => {
+                return Ok(result);
+            }
+            Some(current_pid) => {
+                match parents_to_children.get(&current_pid) {
+                    Some(children) => for child in children {
+                        queue.push(*child);
+                    },
+                    None => (),
+                }
+                result.push(current_pid);
+            }
+        }
+    }
+}
+
+fn map_parents_to_children() -> Result<HashMap<pid_t, Vec<pid_t>>, Error> {
+    let mut pid_map: HashMap<pid_t, Vec<pid_t>> = HashMap::new();
+
+    for (pid, ppid) in get_proc_children()? {
+        pid_map.entry(ppid).or_insert(vec![]).push(pid);
+    }
+    return Ok(pid_map);
+}
+
+#[test]
+fn test_get_descendents() {
+    let mut map = HashMap::new();
+    map.insert(1, vec![2]);
+    let desc = get_descendents(1, map).unwrap();
+    assert_eq!(desc, vec![1, 2]);
+}
+
+#[test]
+fn test_get_descendents_depth_2() {
+    let mut map = HashMap::new();
+    map.insert(1, vec![2, 3]);
+    map.insert(2, vec![4]);
+    let desc = get_descendents(1, map).unwrap();
+    assert_eq!(desc, vec![1, 3, 2, 4]);
+}
+
+// parses /proc/<pid>/status format
+fn status_file_ppid(status: &str) -> Result<pid_t, Error> {
+    let ppid_line = status.split("\n").find(|x| x.starts_with("PPid:"));
+    match ppid_line {
+        Some(line) => {
+            let parts: Vec<&str> = line.split("\t").collect();
+            Ok(parts[1].parse::<pid_t>()?)
+        }
+        None => Err(format_err!("PPid: line not found in {}", status)),
+    }
+}
+
+#[test]
+fn test_status_file_ppid() {
+    let status = "Name:	kthreadd\nState:	S (sleeping)\nTgid:	2\nNgid:	0\nPid:	0\nPPid:	1234\n";
+    assert_eq!(status_file_ppid(status).unwrap(), 1234)
+}
+
+/// Returns pairs of <pid, parent pid>
+#[cfg(target_os = "linux")]
+fn get_proc_children() -> Result<Vec<(pid_t, pid_t)>, Error> {
+    let mut process_pairs = vec![];
+    for entry in read_dir("/proc")? {
+        let entry = entry?;
+        // try parsing the directory name as a PID and see if it works
+        let maybe_pid = entry.file_name().to_string_lossy().parse::<pid_t>();
+        if let Ok(pid) = maybe_pid {
+            let mut contents = String::new();
+            if let Ok(mut f) = File::open(entry.path().join("status")) {
+                f.read_to_string(&mut contents)?;
+                let ppid = status_file_ppid(&contents)?;
+                process_pairs.push((pid, ppid));
+            }
+        }
+    }
+    Ok(process_pairs)
+}
+
+#[cfg(target_os = "macos")]
+fn get_proc_children() -> Result<Vec<(pid_t, pid_t)>, Error> {
+    // TODO
+    panic!("--subprocesses flag isn't implemented on Mac OS yet, sorry!")
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,3 +2,4 @@ pub mod output;
 pub mod callgrind;
 pub mod summary;
 pub mod flamegraph;
+pub mod descendents;


### PR DESCRIPTION
This is #86, but rebased on master and squashed into a single commit. I also removed the glob & procinfo dependencies in favour of just parsing /proc/PID/status manually (since it's like 10 lines of code to parse that file and I'd sorta like to keep dependencies under control).

planning to write maybe marginally better tests then merge it!