### PR TITLE
Ignore C functions in summary rbspy prints out

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod types;
 pub mod initialize;
 mod address_finder;
 pub mod copy;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,0 +1,75 @@
+/// Core types used throughout rbspy: StackFrame and StackTrace
+
+use std::cmp::Ordering;
+use std::fmt;
+use std;
+
+use libc::pid_t;
+use read_process_memory::*;
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct StackFrame {
+    pub name: String,
+    pub relative_path: String,
+    pub absolute_path: Option<String>,
+    pub lineno: u32,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct StackTrace {
+    pub trace: Vec<StackFrame>,
+    pub pid: Option<pid_t>,
+}
+
+pub struct Process<T> where T: CopyAddress {
+    pub pid: Option<pid_t>,
+    pub source: T,
+}
+
+impl StackFrame {
+    pub fn path(&self) -> &str {
+        match self.absolute_path {
+            Some(ref p) => p.as_ref(),
+            None => self.relative_path.as_ref(),
+        }
+    }
+
+    // we use this stack frame when there's a C function that we don't recognize in the stack. This
+    // would be a constant but it has strings in it so it can't be.
+    pub fn unknown_c_function() -> StackFrame {
+        StackFrame {
+            name: "<c function>".to_string(),
+            relative_path: "unknown".to_string(),
+            absolute_path: None,
+            lineno: 0
+        }
+    }
+
+}
+
+impl fmt::Display for StackFrame {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} - {} line {}", self.name, self.path(), self.lineno)
+    }
+}
+
+impl Ord for StackFrame {
+    fn cmp(&self, other: &StackFrame) -> Ordering {
+        self.path()
+            .cmp(other.path())
+            .then(self.name.cmp(&other.name))
+            .then(self.lineno.cmp(&other.lineno))
+    }
+}
+
+impl PartialOrd for StackFrame {
+    fn partial_cmp(&self, other: &StackFrame) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl StackTrace {
+    pub fn iter(&self) ->  std::slice::Iter<StackFrame> {
+        self.trace.iter()
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -18,7 +18,7 @@ use std::io::prelude::*;
 use std::fs::File;
 use std::path::Path;
 
-use core::initialize::StackTrace;
+use core::types::StackTrace;
 
 use self::flate2::Compression;
 use failure::Error;

--- a/src/storage/v0.rs
+++ b/src/storage/v0.rs
@@ -1,6 +1,6 @@
 use std::io::prelude::*;
 use std::io::BufReader;
-use core::initialize::{StackTrace, StackFrame};
+use core::types::{StackTrace, StackFrame};
 
 use failure::Error;
 use serde_json;

--- a/src/storage/v1.rs
+++ b/src/storage/v1.rs
@@ -1,6 +1,6 @@
 use std::io::prelude::*;
 use std::io::BufReader;
-use core::initialize::StackTrace;
+use core::types::StackTrace;
 
 use failure::Error;
 use serde_json;

--- a/src/ui/callgrind.rs
+++ b/src/ui/callgrind.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 use std::collections::{BTreeMap, HashMap};
 use std::io;
 
-use core::initialize::StackFrame;
+use core::types::StackFrame;
 
 /*
  * **Notes about the overall design**

--- a/src/ui/flamegraph.rs
+++ b/src/ui/flamegraph.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-use core::initialize::StackFrame;
+use core::types::StackFrame;
 
 use failure::{Error, ResultExt};
 use tempdir;

--- a/src/ui/output.rs
+++ b/src/ui/output.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use ui::callgrind;
 use ui::summary;
 use ui::flamegraph;
-use core::initialize::StackTrace;
+use core::types::StackTrace;
 
 pub trait Outputter {
     fn record(&mut self, stack: &StackTrace) -> Result<(), Error>;

--- a/src/ui/summary.rs
+++ b/src/ui/summary.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io;
 
-use core::initialize::StackFrame;
+use core::types::StackFrame;
 
 struct Counts {
     self_: u64,

--- a/src/ui/summary.rs
+++ b/src/ui/summary.rs
@@ -42,7 +42,11 @@ impl Stats {
     // Aggregate by function name
     pub fn add_function_name(&mut self, stack: &Vec<StackFrame>) {
         self.total_traces += 1;
-        self.inc_self(Stats::name_function(&stack[0]));
+        let unknown = StackFrame::unknown_c_function();
+        match stack.iter().find(|&x| x != &unknown) {
+            Some(x) => self.inc_self(Stats::name_function(x)),
+            None => self.inc_self(Stats::name_function(&unknown))
+        }
         let mut set: HashSet<String> = HashSet::new();
         for frame in stack {
             set.insert(Stats::name_function(frame));
@@ -55,7 +59,13 @@ impl Stats {
     // Aggregate by function name + line number
     pub fn add_lineno(&mut self, stack: &Vec<StackFrame>) {
         self.total_traces += 1;
-        self.inc_self(Stats::name_lineno(&stack[0]));
+        let unknown = StackFrame::unknown_c_function();
+        // ignore C functions at the top of the stack because it's not really helpful to include
+        // them
+        match stack.iter().find(|&x| x != &unknown) {
+            Some(x) => self.inc_self(Stats::name_lineno(x)),
+            None => self.inc_self(Stats::name_lineno(&unknown))
+        }
         let mut set: HashSet<&StackFrame> = HashSet::new();
         for frame in stack { set.insert(&frame); }
         for frame in set {


### PR DESCRIPTION
Previously we were including C functions in the summary rbspy prints out. I think it's appropriate to include C functions in a flamegraph, but in the summary they were just causing confusion -- it would report something like "50% of time spend in unknown C function", when in reality those are all probably different C functions.

With this PR, "unknown C function" is only included in the summary if it's the only thing in the stack trace.