### PR TITLE
Fix bug with profiling system Ruby

### DIFF
--- a/src/core/copy.rs
+++ b/src/core/copy.rs
@@ -5,7 +5,7 @@ use read_process_memory::*;
  * Utility functions for copying memory out of a process
  */
 
-const MAX_COPY_LENGTH: usize = 1000000;
+const MAX_COPY_LENGTH: usize = 20000000;
 
 #[derive(Fail, Debug)]
 pub enum MemoryCopyError {

--- a/src/core/initialize.rs
+++ b/src/core/initialize.rs
@@ -91,7 +91,7 @@ impl StackTrace {
 // Use a StackTraceGetter to get stack traces
 pub struct StackTraceGetter<T> where T: CopyAddress {
     process: Process<T>,
-    current_thread_addr_location: usize,
+    pub current_thread_addr_location: usize,
     stack_trace_function:
         Box<Fn(usize, &Process<T>) -> Result<StackTrace, MemoryCopyError>>,
 }
@@ -220,6 +220,19 @@ fn test_current_thread_address() {
     process.kill().unwrap();
 }
 
+#[test]
+#[cfg(target_os = "linux")]
+fn test_get_trace() {
+    // Test getting a stack trace from a real running program using system Ruby
+    let mut process = std::process::Command::new("/usr/bin/ruby").arg("./ci/ruby-programs/infinite.rb").spawn().unwrap();
+    let pid = process.id() as pid_t;
+    let getter = initialize(pid).unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    let trace = getter.get_trace();
+    assert!(trace.is_ok());
+    assert_eq!(trace.unwrap().pid, Some(pid));
+    process.kill().unwrap();
+}
 
 #[test]
 #[cfg(target_os = "macos")]
@@ -244,7 +257,7 @@ fn test_get_disallowed_process() {
 
 fn is_maybe_thread_function<T: 'static>(
     version: &str,
-) -> Box<Fn(usize, &T, &Vec<MapRange>) -> bool>
+) -> Box<Fn(usize, usize, T, &Vec<MapRange>) -> bool>
 where
     T: CopyAddress,
 {


### PR DESCRIPTION
cc @parkr

Fixes #111 

At some point we introduced a bug where profiling Ruby processes with no symbols stopped working, because we broke the heuristic for finding the address of the current thread. I'm not sure what broke this exactly, but instead of figuring out what went wrong this just makes the logic a lot more robust.

In addition to looking at various random heuristics, at the end of the `is_maybe_thread` we try to get a stack trace assuming that the address we pass in is the actual address of the current thread, and see if it works. That's kind of the ultimate test so it should be much more reliable :)

Also added a regression test to make sure that the bug doesn't come back.