### PR TITLE
Add test to verify unicode support

### DIFF
--- a/ci/docker-tests.sh
+++ b/ci/docker-tests.sh
@@ -24,6 +24,10 @@ do
 
    echo -n "subprocess identification"
    docker run -v=/tmp/artifacts:/stuff rb-stacktrace-$distro env RUST_BACKTRACE=1 /stuff/rbspy record --subprocesses /usr/bin/ruby /stuff/ruby_forks.rb
+
+   echo -n "unicode test"
+   docker run -v=/tmp/artifacts:/stuff rb-stacktrace-$distro env RUST_BACKTRACE=1 /stuff/rbspy record --file /tmp/stacks.txt /usr/bin/ruby /stuff/unicode_stack.rb
+   grep € /tmp/stacks.txt
 done
 
 echo "=================="

--- a/ci/ruby-programs/unicode_stack.rb
+++ b/ci/ruby-programs/unicode_stack.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+
+class Test
+  # U+20AC
+  def self.€
+    sleep 0.25
+  end
+end
+
+Test.€


### PR DESCRIPTION
Not every method in the stack trace will be ASCII so add an explicit test to handle potential regressions.