### PR TITLE
Include sys_ptrace capability information in the error

### DIFF
--- a/src/core/address_finder.rs
+++ b/src/core/address_finder.rs
@@ -12,7 +12,7 @@ use libc::pid_t;
 #[derive(Fail, Debug)]
 pub enum AddressFinderError {
     #[fail(display = "No process with PID: {}", _0)] NoSuchProcess(pid_t),
-    #[fail(display = "Permission denied when reading from process {}. Try again with sudo?", _0)]
+    #[fail(display = "Permission denied when reading from process {}. Try again with sudo and check sys_ptrace capability?", _0)]
     PermissionDenied(pid_t),
     #[fail(display = "Couldn't get port for PID {}. Possibilities: that process doesn't exist or you have SIP enabled and you're trying to profile system Ruby (try rbenv instead).", _0)]
     MacPermissionDenied(pid_t),

--- a/src/core/copy.rs
+++ b/src/core/copy.rs
@@ -9,7 +9,7 @@ const MAX_COPY_LENGTH: usize = 20000000;
 
 #[derive(Fail, Debug)]
 pub enum MemoryCopyError {
-    #[fail(display = "Permission denied when reading from process. Try again with sudo?")]
+    #[fail(display = "Permission denied when reading from process. Try again with sudo and check sys_ptrace capability?")]
     PermissionDenied,
     #[fail(display = "Failed to copy memory address {:x}", _0)] Io(usize, #[cause] std::io::Error),
     #[fail(display = "Process isn't running")] ProcessEnded,


### PR DESCRIPTION
Add a more helpful message when permission denied errors arise. See #119 for a little background.

Note: This is a Linux specific error that came up for me under docker. Fix it in docker with `docker run --cap-add SYS_PTRACE`