### PR TITLE
Get stacks starting from ruby_current_vm instead of ruby_current_thread

### DIFF
--- a/src/core/copy.rs
+++ b/src/core/copy.rs
@@ -14,6 +14,7 @@ pub enum MemoryCopyError {
     PermissionDenied,
     #[fail(display = "Failed to copy memory address {:x}", _0)] Io(usize, #[cause] std::io::Error),
     #[fail(display = "Process isn't running")] ProcessEnded,
+    #[fail(display = "Invalid stack size")] InvalidStackSize,
     #[fail(display = "Copy error: {}", _0)] Message(String),
     #[fail(display = "Too much memory requested when copying: {}", _0)] RequestTooLarge(usize),
     #[fail(display = "Tried to read invalid string")]


### PR DESCRIPTION
Previously we were getting stacks starting from `ruby_current_thread`. `(ruby_current_thread->cfp->...)`. This changes it so that instead start at the `ruby_current_vm` symbol, and do `ruby_current_vm->running_thread->cfp->...`.

The main thing this will get us (in my next PR, tomorrow or so) is easier access to whether the Ruby VM is currently garbage collecting or not, which is `ruby_current_vm->objspace->during_gc`.