### PR TITLE
Filter out 'unknown C function' functions when generating callgrind summary

### DIFF
--- a/src/ui/summary.rs
+++ b/src/ui/summary.rs
@@ -42,11 +42,7 @@ impl Stats {
     // Aggregate by function name
     pub fn add_function_name(&mut self, stack: &Vec<StackFrame>) {
         self.total_traces += 1;
-        let unknown = StackFrame::unknown_c_function();
-        match stack.iter().find(|&x| x != &unknown) {
-            Some(x) => self.inc_self(Stats::name_function(x)),
-            None => self.inc_self(Stats::name_function(&unknown))
-        }
+        self.inc_self(Stats::name_function(&stack[0]));
         let mut set: HashSet<String> = HashSet::new();
         for frame in stack {
             set.insert(Stats::name_function(frame));
@@ -59,13 +55,7 @@ impl Stats {
     // Aggregate by function name + line number
     pub fn add_lineno(&mut self, stack: &Vec<StackFrame>) {
         self.total_traces += 1;
-        let unknown = StackFrame::unknown_c_function();
-        // ignore C functions at the top of the stack because it's not really helpful to include
-        // them
-        match stack.iter().find(|&x| x != &unknown) {
-            Some(x) => self.inc_self(Stats::name_lineno(x)),
-            None => self.inc_self(Stats::name_lineno(&unknown))
-        }
+        self.inc_self(Stats::name_lineno(&stack[0]));
         let mut set: HashSet<&StackFrame> = HashSet::new();
         for frame in stack { set.insert(&frame); }
         for frame in set {


### PR DESCRIPTION
Since different instances of 'unknown C function' may refer to totally different functions, it confuses the callgrind output and doesn't really help you figure out what's going on at all.

We leave in "unknown C function" if it's the only function on the stack.