### PR TITLE
Measure how much time is spent on CPU

### DIFF
--- a/src/core/ruby_version.rs
+++ b/src/core/ruby_version.rs
@@ -150,21 +150,50 @@ macro_rules! get_stack_trace(
 
         use crate::core::types::*;
         use crate::core::types::StackFrame;
+        use failure::Error;
+        use libc::pid_t;
 
         pub fn get_stack_trace<T>(
             ruby_current_thread_address_location: usize,
             process: &Process<T>,
             ) -> Result<StackTrace, MemoryCopyError> where T: CopyAddress {
+            let trace = get_stack_frames(ruby_current_thread_address_location, process)?;
+            let pid = process.pid;
+            let on_cpu = get_cpu(pid).ok();
+            Ok(StackTrace{on_cpu, trace, pid, thread_id: None})
+        }
+
+        fn get_cpu(maybe_pid: Option<pid_t>) -> Result<bool, Error> {
+            match maybe_pid {
+                None => Err(format_err!("no pid given")),
+                Some(pid) => on_cpu(pid),
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        fn on_cpu(pid: pid_t) -> Result<bool, Error> {
+            use std::fs::File;
+            use std::io::Read;
+            let mut contents = String::new();
+            File::open(format!("/proc/{}/status", pid))?.read_to_string(&mut contents)?;
+            Ok(contents.contains("State:\tR"))
+        }
+
+        #[cfg(target_os = "macos")]
+        fn on_cpu(pid: pid_t) -> Result<bool, Error>{
+            Err(format_err!("Checking CPU status of process not supported on Mac"))
+        }
+
+        fn get_stack_frames<T>(
+            ruby_current_thread_address_location: usize,
+            process: &Process<T>,
+            ) -> Result<Vec<StackFrame>, MemoryCopyError> where T: CopyAddress {
             let source = &process.source;
             let current_thread_addr: usize =
                 copy_struct(ruby_current_thread_address_location, source)?;
             let thread: $thread_type = copy_struct(current_thread_addr, source)?;
             if stack_field(&thread) as usize == 0 {
-                return Ok(StackTrace {
-                    pid: process.pid,
-                    trace: vec!(StackFrame::unknown_c_function()),
-                    thread_id: Some(get_thread_id(&thread, source)?)
-                });
+                return Ok(vec!(StackFrame::unknown_c_function()));
             }
             let mut trace = Vec::new();
             let cfps = get_cfps(thread.cfp as usize, stack_base(&thread) as usize, source)?;
@@ -203,7 +232,7 @@ macro_rules! get_stack_trace(
                     }
                 }
             }
-            Ok(StackTrace{trace, pid: process.pid, thread_id: Some(get_thread_id(&thread, source)?)})
+            Ok(trace)
         }
 
 use proc_maps::{maps_contain_addr, MapRange};

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -23,8 +23,11 @@ pub struct StackFrame {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct StackTrace {
     pub trace: Vec<StackFrame>,
+    // these are both options for backwards compatibility with older rbspy saved data that didn't
+    // have PID / cpu data
     pub pid: Option<pid_t>,
     pub thread_id: Option<usize>,
+    pub on_cpu: Option<bool>,
 }
 
 pub struct Process<T> where T: CopyAddress {

--- a/src/main.rs
+++ b/src/main.rs
@@ -433,7 +433,7 @@ fn parallel_record(
 
     for trace in trace_receiver.iter() {
         out.record(&trace)?;
-        summary_out.add_function_name(&trace.trace);
+        summary_out.add_function_name(&trace);
         raw_store.write(&trace)?;
 
         if !silent {
@@ -563,10 +563,13 @@ fn print_summary(summary_out: &ui::summary::Stats, start_time: &Instant, sample_
     println!("{}[2J", 27 as char); // clear screen
     println!("{}[0;0H", 27 as char); // go to 0,0
     eprintln!("Time since start: {}s. Press Ctrl+C to stop.", start_time.elapsed().as_secs());
-    let percent_timing_error = (timing_error_traces as f64) / (total_traces as f64) * 100.0;
+    if let Some(cpu_percent) = summary_out.cpu_percent() {
+        eprintln!("% of time spent on CPU: {:.2}", cpu_percent * (100 as f64));
+    }
     eprintln!("Summary of profiling data so far:");
     summary_out.print_top_n(20, width)?;
 
+    let percent_timing_error = (timing_error_traces as f64) / (total_traces as f64) * 100.0;
     if total_traces > 100 && percent_timing_error > 0.5 {
         // Only print if timing errors are more than 0.5% of total traces -- it's a statistical
         // profiler so smaller differences don't really matter

--- a/src/storage/v0.rs
+++ b/src/storage/v0.rs
@@ -33,6 +33,6 @@ impl From<Data> for v1::Data {
 
 impl From<Vec<StackFrame>> for StackTrace {
     fn from(trace: Vec<StackFrame>) -> StackTrace {
-        StackTrace{pid: None, trace, thread_id: None}
+        StackTrace{pid: None, on_cpu: None, thread_id: None, trace}
     }
 }


### PR DESCRIPTION
This measures how much time overall the program we're profiling is spending on the CPU! This opens up some exciting visualization possibilities -- now that we're recording whether or not each stack trace is on the CPU or not, we can do things like add an `--on-cpu` / `--off-cpu` to `rbspy report` to only include stack traces where the program was / wasn't using the CPU.

Only works on Linux so far.