### PR TITLE
Make rbspy -V report the version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "rbspy"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbspy"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Julia Evans <julia@jvns.ca>"]
 description = "Sampling CPU profiler for Ruby"
 keywords = ["ruby", "profiler", "MRI"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -595,6 +595,7 @@ fn validate_filename(s: String) -> Result<(), String> {
 
 fn arg_parser() -> App<'static, 'static> {
     App::new("rbspy")
+        .version(env!("CARGO_PKG_VERSION"))
         .about("Sampling profiler for Ruby programs")
         .setting(AppSettings::SubcommandRequired)
         .subcommand(


### PR DESCRIPTION
Fixes https://github.com/rbspy/rbspy/issues/130. This will automatically get the version from the Cargo.toml configuration file.

Also the version in the Cargo.toml file wasn't up to date.