### PR TITLE
Skip summarizing traces with length 0

### DIFF
--- a/src/ui/summary.rs
+++ b/src/ui/summary.rs
@@ -41,6 +41,9 @@ impl Stats {
 
     // Aggregate by function name
     pub fn add_function_name(&mut self, stack: &Vec<StackFrame>) {
+        if stack.len() == 0 {
+            return;
+        }
         self.total_traces += 1;
         self.inc_self(Stats::name_function(&stack[0]));
         let mut set: HashSet<String> = HashSet::new();
@@ -54,6 +57,9 @@ impl Stats {
 
     // Aggregate by function name + line number
     pub fn add_lineno(&mut self, stack: &Vec<StackFrame>) {
+        if stack.len() == 0 {
+            return;
+        }
         self.total_traces += 1;
         self.inc_self(Stats::name_lineno(&stack[0]));
         let mut set: HashSet<&StackFrame> = HashSet::new();


### PR DESCRIPTION
Hopefully fixes https://github.com/rbspy/rbspy/issues/141

It looks like sometimes we're getting stack traces with length 0. I'm not sure yet why this would be happening, but checking for that and not including them in the summary might resolve it.