### PR TITLE
Fix MacPermissionDenied compile warning

### DIFF
--- a/src/core/address_finder.rs
+++ b/src/core/address_finder.rs
@@ -15,6 +15,7 @@ pub enum AddressFinderError {
     #[fail(display = "Permission denied when reading from process {}. Try again with sudo and check sys_ptrace capability?", _0)]
     PermissionDenied(pid_t),
     #[fail(display = "Couldn't get port for PID {}. Possibilities: that process doesn't exist or you have SIP enabled and you're trying to profile system Ruby (try rbenv instead).", _0)]
+    #[cfg(target_os = "macos")]
     MacPermissionDenied(pid_t),
     #[fail(display = "Error reading /proc/{}/maps", _0)] ProcMapsError(pid_t),
 }

--- a/src/core/initialize.rs
+++ b/src/core/initialize.rs
@@ -89,6 +89,7 @@ fn get_ruby_version_retry(pid: pid_t) -> Result<String, Error> {
                     Some(&AddressFinderError::PermissionDenied(_)) => {
                         return Err(err.into());
                     }
+                    #[cfg(target_os = "macos")]
                     Some(&AddressFinderError::MacPermissionDenied(_)) => {
                         return Err(err.into());
                     }


### PR DESCRIPTION
Previously we were getting this compile warning on Linux

```
warning: variant is never constructed: `MacPermissionDenied`
  --> src/core/address_finder.rs:18:5
   |
18 |     MacPermissionDenied(pid_t),
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(dead_code)] on by default
```

This fixes it by only including the variant on Mac.