### PR TITLE
[Closes #148] Support --subprocesses flag on Mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libproc"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -426,7 +426,7 @@ dependencies = [
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "libproc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libproc 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mach 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -790,7 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
-"checksum libproc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb1b082528c20123beb4f8f4028c16041fa95d3b07998dbc192a9f8912b5df1"
+"checksum libproc 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab823629d82196517622abe17f989537e2637ac064bca9489c9217d35d933e"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum mach 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "196697f416cf23cf0d3319cf5b2904811b035c82df1dfec2117fb457699bf277"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tempdir = "0.3"
 [target.'cfg(target_os="macos")'.dependencies]
 mach = "0.1.2"
 regex = "0.2.3"
-libproc = "0.2.0"
+libproc = "0.3.1"
 lazy_static = "1.0.0"
 object = "0.1.0"
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -10,7 +10,12 @@ set -ex
 # `before_deploy`/packaging phase
 run_test_suite() {
     cargo build --target $TARGET --verbose
-    cargo test --target $TARGET
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]
+    then
+        cargo test --target $TARGET
+    else
+        sudo cargo test --target $TARGET
+    fi
 
     # sanity check the file type
     file target/$TARGET/debug/rbspy

--- a/src/core/mac_maps.rs
+++ b/src/core/mac_maps.rs
@@ -135,10 +135,10 @@ fn mach_vm_region(
 
 pub fn task_for_pid(pid: pid_t) -> io::Result<mach_port_name_t> {
     let mut task: mach_port_name_t = MACH_PORT_NULL;
-    // sleep for 5ms to make sure we don't get into a race between `task_for_pid` and execing a new
+    // sleep for 10ms to make sure we don't get into a race between `task_for_pid` and execing a new
     // process. Races here can freeze the OS because of a Mac kernel bug on High Sierra.
     // See https://jvns.ca/blog/2018/01/28/mac-freeze/ for more.
-    std::thread::sleep(std::time::Duration::from_millis(5));
+    std::thread::sleep(std::time::Duration::from_millis(10));
     unsafe {
         let result =
             mach::traps::task_for_pid(mach::traps::mach_task_self(), pid as c_int, &mut task);

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,12 +365,15 @@ fn spawn_recorder_children(pid: pid_t, with_subprocesses: bool, sample_rate: u32
 }
 
 #[test]
-#[cfg(target_os = "linux")]
 fn test_spawn_record_children_subprocesses() {
-    // Test that when we spawn a bunch of child threads to record subprocesses that we actually
-    // record stack traces for different PIDs
-    // We only run this test on linux because the subprocess code doesn't work on Mac yet
-    let mut process = std::process::Command::new("/usr/bin/ruby").arg("ci/ruby-programs/ruby_forks.rb").spawn().unwrap();
+    let output = Command::new("/usr/bin/which")
+        .arg("ruby")
+        .output()
+        .expect("failed to execute process");
+
+    let ruby_binary_path = String::from_utf8(output.stdout).unwrap();
+
+    let mut process = std::process::Command::new(ruby_binary_path.trim()).arg("ci/ruby-programs/ruby_forks.rb").spawn().unwrap();
     let pid = process.id() as pid_t;
     let (trace_receiver, result_receiver, _, _) = spawn_recorder_children(pid, true, 10, None).unwrap();
     process.wait().unwrap();


### PR DESCRIPTION
Currently --subprocesses flag is not available on darwin platform,
because subprocess retrieving logic is Linux-specific.

This change
* Bumps `libproc` version to "0.3.1", because the new version
  introduces `proc_pid::pidinfo` function, useful for retrieving
  PPIDs.
* Implements darwin-specific `ui::descendents::descendents_of` based
  on the new `libproc` functionality.
* Enables `test_spawn_record_children_subprocesses` test for darwin
  and tweaks it not to use system Ruby for reasons described in #69