### PR TITLE
Include an output format for speedscope

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,7 @@ arg_enum!{
     pub enum OutputFormat {
         flamegraph,
         callgrind,
+        speedscope,
         summary,
         summary_by_line,
     }
@@ -227,6 +228,7 @@ impl OutputFormat {
         match self {
             OutputFormat::flamegraph => Box::new(output::Flamegraph(ui::flamegraph::Stats::new())),
             OutputFormat::callgrind => Box::new(output::Callgrind(ui::callgrind::Stats::new())),
+            OutputFormat::speedscope => Box::new(output::Speedscope(ui::speedscope::Stats::new())),
             OutputFormat::summary => Box::new(output::Summary(ui::summary::Stats::new())),
             OutputFormat::summary_by_line => Box::new(output::SummaryLine(ui::summary::Stats::new())),
         }
@@ -236,6 +238,7 @@ impl OutputFormat {
         match self {
             &OutputFormat::flamegraph => "flamegraph.svg",
             &OutputFormat::callgrind => "callgrind.txt",
+            &OutputFormat::speedscope => "speedscope.json",
             &OutputFormat::summary => "summary.txt",
             &OutputFormat::summary_by_line => "summary_by_line.txt",
         }.to_string()

--- a/src/ui/descendents.rs
+++ b/src/ui/descendents.rs
@@ -112,6 +112,12 @@ fn get_proc_children() -> Result<Vec<(pid_t, pid_t)>, Error> {
 
     let pids = listpids(ProcType::ProcAllPIDS).map_err(convert_error)?;
 
+    // I had to make this modification to fix a cargo build error!
+    // I should figure out a better fix before trying to land this as a PR.
+    let convert_error = |err| {
+        format_err!("Unable to retrieve process parent PID ({})", err)
+    };
+
     let ppids = pids
         .iter()
         .map(|&pid| {

--- a/src/ui/descendents.rs
+++ b/src/ui/descendents.rs
@@ -112,12 +112,6 @@ fn get_proc_children() -> Result<Vec<(pid_t, pid_t)>, Error> {
 
     let pids = listpids(ProcType::ProcAllPIDS).map_err(convert_error)?;
 
-    // I had to make this modification to fix a cargo build error!
-    // I should figure out a better fix before trying to land this as a PR.
-    let convert_error = |err| {
-        format_err!("Unable to retrieve process parent PID ({})", err)
-    };
-
     let ppids = pids
         .iter()
         .map(|&pid| {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,3 +3,4 @@ pub mod callgrind;
 pub mod summary;
 pub mod flamegraph;
 pub mod descendents;
+pub mod speedscope;

--- a/src/ui/output.rs
+++ b/src/ui/output.rs
@@ -77,7 +77,7 @@ pub struct Speedscope(pub speedscope::Stats);
 
 impl Outputter for Speedscope {
     fn record(&mut self, stack: &StackTrace) -> Result<(), Error> {
-        self.0.record(&stack.trace)?;
+        self.0.record(&stack)?;
         Ok(())
     }
 

--- a/src/ui/output.rs
+++ b/src/ui/output.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use ui::callgrind;
 use ui::summary;
 use ui::flamegraph;
+use ui::speedscope;
 use core::types::{StackTrace, StackFrame};
 
 pub trait Outputter {
@@ -68,6 +69,20 @@ impl Outputter for SummaryLine {
 
     fn complete(&mut self, mut file: File) -> Result<(), Error> {
         self.0.write(&mut file)?;
+        Ok(())
+    }
+}
+
+pub struct Speedscope(pub speedscope::Stats);
+
+impl Outputter for Speedscope {
+    fn record(&mut self, stack: &StackTrace) -> Result<(), Error> {
+        self.0.record(&stack.trace)?;
+        Ok(())
+    }
+
+    fn complete(&mut self, file: File) -> Result<(), Error> {
+        self.0.write(file)?;
         Ok(())
     }
 }

--- a/src/ui/speedscope.rs
+++ b/src/ui/speedscope.rs
@@ -147,7 +147,7 @@ impl Stats {
     }
 
     pub fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), io::Error> {
-        let frame_indices: Vec<usize> = stack.into_iter().map(|frame| {
+        let mut frame_indices: Vec<usize> = stack.into_iter().map(|frame| {
             let frames = &mut self.frames;
             self.frame_to_index.entry(frame.clone()).or_insert_with(|| {
                 let len = frames.len();
@@ -155,6 +155,7 @@ impl Stats {
                 len
             }).clone()
         }).collect();
+        frame_indices.reverse();
         self.samples.push(frame_indices);
         Ok(())
     }

--- a/src/ui/speedscope.rs
+++ b/src/ui/speedscope.rs
@@ -11,8 +11,11 @@ use serde_json;
 /*
  * This file contains code to export rbspy profiles for use in https://speedscope.app
  *
- * The speedscope file format is specified via a JSON schema.
- * The latest schema can be found here: https://speedscope.app/file-format-schema.json
+ * The TypeScript definitions that define this file format can be found here:
+ * https://github.com/jlfwong/speedscope/blob/9d13d9/src/lib/file-format-spec.ts
+ *
+ * From the TypeScript definition, a JSON schema is generated. The latest
+ * schema can be found here: https://speedscope.app/file-format-schema.json
  *
  * This JSON schema conveniently allows to generate type bindings for generating JSON.
  * You can use https://app.quicktype.io/ to generate serde_json Rust bindings for the
@@ -29,7 +32,13 @@ struct SpeedscopeFile {
     schema: String,
     profiles: Vec<Profile>,
     shared: Shared,
-    version: String,
+
+    #[serde(rename = "activeProfileIndex")]
+    active_profile_index: Option<f64>,
+
+    exporter: Option<String>,
+
+    name: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -97,8 +106,11 @@ impl SpeedscopeFile {
       // This is always the same
       schema: "https://www.speedscope.app/file-format-schema.json".to_string(),
 
-      // This is the version of the file format we're targeting
-      version: "0.2.0".to_string(),
+      active_profile_index: None,
+
+      name: None,
+
+      exporter: Some(format!("rbspy@{}", env!("CARGO_PKG_VERSION"))),
 
       profiles: vec![Profile {
         profile_type: ProfileType::Sampled,

--- a/src/ui/speedscope.rs
+++ b/src/ui/speedscope.rs
@@ -1,0 +1,143 @@
+use std::collections::HashMap;
+use std::io;
+
+use core::types::StackFrame;
+
+use serde_json;
+
+/*
+ * The speedscope file format is specified via a JSON schema.
+ * The latest schema can be found here: https://speedscope.app/file-format-schema.json
+ *
+ * This JSON schema conveniently allows to generate type bindings for generating JSON.
+ * You can use https://app.quicktype.io/ to generate serde_json Rust bindings for the
+ * given JSON schema.
+ *
+ * There are multiple variants of the file format. The variant we're going to generate
+ * is the "type: sampled" profile, since it most closely maps to rbspy's data recording
+ * structure.
+ */
+
+// Modifications to generated code
+// - renamed Frame to Frame
+// - made Frame derive Hash
+// START OF GENERATED TYPED BINDINGS
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SpeedscopeFile {
+    #[serde(rename = "$schema")]
+    schema: Schema,
+    profiles: Vec<Profile>,
+    shared: Shared,
+    version: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Profile {
+    #[serde(rename = "endValue")]
+    end_value: f64,
+    events: Option<Vec<Event>>,
+    name: String,
+    #[serde(rename = "startValue")]
+    start_value: f64,
+    #[serde(rename = "type")]
+    profile_type: ProfileType,
+    unit: ValueUnit,
+    samples: Option<Vec<Vec<f64>>>,
+    weights: Option<Vec<f64>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Event {
+    at: f64,
+    frame: f64,
+    #[serde(rename = "type")]
+    event_type: EventType,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Shared {
+    frames: Vec<FormatFrame>,
+}
+
+#[derive(Hash, Debug, Serialize, Deserialize)]
+pub struct Frame {
+    col: Option<f64>,
+    file: Option<String>,
+    line: Option<f64>,
+    name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum EventType {
+    C,
+    O,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ProfileType {
+    #[serde(rename = "evented")]
+    Evented,
+    #[serde(rename = "sampled")]
+    Sampled,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ValueUnit {
+    #[serde(rename = "bytes")]
+    Bytes,
+    #[serde(rename = "microseconds")]
+    Microseconds,
+    #[serde(rename = "milliseconds")]
+    Milliseconds,
+    #[serde(rename = "nanoseconds")]
+    Nanoseconds,
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "seconds")]
+    Seconds,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Schema {
+    #[serde(rename = "https://www.speedscope.app/file-format-schema.json")]
+    HttpsWwwSpeedscopeAppSchemaJson,
+}
+// END OF GENERATED TYPED BINDINGS
+
+impl SpeedscopeFile {
+  pub fn new(profile: Sampled, frames: HashSet<Frame>) -> SpeedscopeFile {
+    SpeedscopeFile {
+      // This is always the same
+      schema: HttpsWwwSpeedscopeAppSchemaJson,
+
+      // This is the version of the file format we're targeting
+      version: "0.2.0",
+
+      profiles: vec![profile],
+
+      shared: Shared {
+        frames
+      }
+    }
+  }
+}
+
+pub struct Stats {
+  pub profile: Sampled
+  pub frames: Vec<Frame>
+  pub frameToIndex: HashMap<Frame, u32>
+}
+
+impl Stats {
+  pub fn new() -> Stats {
+    Stats {
+      file: SpeedscopeFile
+    }
+  }
+
+  pub fn record(&mut self, stack: &Vec<StackFrame>) -> Result<(), io::Error> {
+  }
+
+  pub fn write(&self, w: File) -> Result<(), Error> {
+  }
+}

--- a/src/ui/speedscope.rs
+++ b/src/ui/speedscope.rs
@@ -3,8 +3,7 @@ use std::io;
 use std::io::Write;
 use std::fs::File;
 
-use libc::pid_t;
-use core::types::{StackTrace, StackFrame};
+use core::types::{pid_t, StackTrace, StackFrame};
 
 use failure::{Error};
 use serde_json;

--- a/src/ui/speedscope.rs
+++ b/src/ui/speedscope.rs
@@ -107,7 +107,7 @@ impl SpeedscopeFile {
 
       active_profile_index: None,
 
-      name: None,
+      name: "rbspy profile",
 
       exporter: Some(format!("rbspy@{}", env!("CARGO_PKG_VERSION"))),
 
@@ -117,7 +117,7 @@ impl SpeedscopeFile {
         return Profile {
             profile_type: ProfileType::Sampled,
 
-            name: option_pid.map_or("".to_string(), |pid| format!("pid {}", pid)),
+            name: option_pid.map_or("rbspy profile".to_string(), |pid| format!("rbspy profile - pid {}", pid)),
 
             unit: ValueUnit::None,
 

--- a/src/ui/speedscope.rs
+++ b/src/ui/speedscope.rs
@@ -107,7 +107,7 @@ impl SpeedscopeFile {
 
       active_profile_index: None,
 
-      name: "rbspy profile",
+      name: Some("rbspy profile".to_string()),
 
       exporter: Some(format!("rbspy@{}", env!("CARGO_PKG_VERSION"))),
 

--- a/src/ui/speedscope.rs
+++ b/src/ui/speedscope.rs
@@ -125,7 +125,7 @@ impl Frame {
         Frame {
             name: stack_frame.name.clone(),
             file: Some(stack_frame.relative_path.clone()),
-            line: None,
+            line: Some(stack_frame.lineno),
             col: None
         }
     }


### PR DESCRIPTION
Hi! This is a PR to generate output from rbspy that can be consumed by https://www.speedscope.app/ for fast interactive flamechart visualization & exploration in-browser.

To test this out, generate a profile, then convert it to a speedscope json file like so:

```
report -i /Users/jlfwong/.cache/rbspy/records/rbspy-2018-07-12-4h5BlXOheu.raw.gz -f speedscope -o ~/Downloads/foo.speedscope.json
```

Then drop the resulting `.speedscope.json` file into https://www.speedscope.app/

This is my first ever PR in Rust, so I expect there to be a lot of changes needed before this can plausibly land.

My eventual plan is to make this integration even more seamless, so you don't even need to find the json file output and drag it into browser. Ideally you'd be able to do something like `rbspy view /path/to/profile`, and it would open the profile in-browser automatically using a checked-in copy of speedscope. That was the approach I proposed in https://github.com/tmm1/stackprof/pull/100. This PR is just the first step to generate a form that speedscope can consume.

I first asked about potential integration with rbspy in this tweet :) https://twitter.com/jlfwong/status/1015844929027780608

Fixes jlfwong/speedscope#31