### PR TITLE
refactor proc_maps into a submodule

### DIFF
--- a/src/core/address_finder.rs
+++ b/src/core/address_finder.rs
@@ -23,7 +23,7 @@ pub enum AddressFinderError {
 #[cfg(target_os = "macos")]
 mod os_impl {
     use core::address_finder::AddressFinderError;
-    use core::proc_maps::{MapRange, get_process_maps};
+    use core::proc_maps::*;
     use core::proc_maps::mac_maps::{Symbol, get_symbols};
 
     use failure::Error;

--- a/src/core/address_finder.rs
+++ b/src/core/address_finder.rs
@@ -23,8 +23,8 @@ pub enum AddressFinderError {
 #[cfg(target_os = "macos")]
 mod os_impl {
     use core::address_finder::AddressFinderError;
-    use core::proc_maps::MapRange;
-    use core::mac_maps::*;
+    use core::proc_maps::{MapRange, get_process_maps};
+    use core::proc_maps::mac_maps::{Symbol, get_symbols};
 
     use failure::Error;
     use libc::pid_t;
@@ -101,10 +101,9 @@ mod os_impl {
     }
 
     fn get_program_info(pid: pid_t) -> Result<ProgramInfo, Error> {
-        let task = task_for_pid(pid).map_err(|_| {
+        let maps = get_process_maps(pid).map_err(|_| {
             AddressFinderError::MacPermissionDenied(pid)
         })?;
-        let maps = get_process_maps(pid, task);
         let ruby_binary = get_ruby_binary(&maps)?;
         let libruby_binary = get_libruby_binary(&maps);
         Ok(ProgramInfo {
@@ -113,20 +112,20 @@ mod os_impl {
         })
     }
 
-    fn get_ruby_binary(maps: &Vec<MacMapRange>) -> Result<Binary, Error> {
-        let map: &MacMapRange = maps.iter()
-            .find(|ref m| if let Some(ref pathname) = m.filename {
+    fn get_ruby_binary(maps: &[MapRange]) -> Result<Binary, Error> {
+        let map: &MapRange = maps.iter()
+            .find(|ref m| if let Some(ref pathname) = m.filename() {
                 pathname.contains("bin/ruby") && m.is_exec()
             } else {
                 false
             })
             .ok_or(format_err!("Couldn't find ruby map"))?;
-        Binary::from(map.start as usize, map.filename.as_ref().unwrap())
+        Binary::from(map.start() as usize, map.filename().as_ref().unwrap())
     }
 
-    fn get_libruby_binary(maps: &Vec<MacMapRange>) -> Option<Binary> {
+    fn get_libruby_binary(maps: &[MapRange]) -> Option<Binary> {
         let maybe_map = maps.iter().find(
-            |ref m| if let Some(ref pathname) = m.filename {
+            |ref m| if let Some(ref pathname) = m.filename() {
                 pathname.contains("libruby") && m.is_exec()
             } else {
                 false
@@ -134,7 +133,7 @@ mod os_impl {
         );
         match maybe_map.as_ref() {
             Some(map) => Some(
-                Binary::from(map.start as usize, map.filename.as_ref().unwrap()).unwrap(),
+                Binary::from(map.start() as usize, map.filename().as_ref().unwrap()).unwrap(),
             ),
             None => None,
         }
@@ -241,7 +240,7 @@ mod os_impl {
         );
         let load_header = elf_load_header(libruby_elf);
         debug!("bss_section header: {:?}", bss_section);
-        let read_addr = map.range_start + bss_section.addr as usize - load_header.vaddr as usize;
+        let read_addr = map.start() + bss_section.addr as usize - load_header.vaddr as usize;
 
         debug!("read_addr: {:x}", read_addr);
         let source = proginfo.pid.try_into_process_handle().unwrap();
@@ -290,7 +289,7 @@ mod os_impl {
         elf_symbol_value(elf_file, symbol_name).map(|addr| {
             let load_header = elf_load_header(elf_file);
             debug!("load header: {}", load_header);
-            map.range_start + addr - load_header.vaddr as usize
+            map.start() + addr - load_header.vaddr as usize
         })
     }
 
@@ -320,23 +319,23 @@ mod os_impl {
         // mount namespace. /proc/PID/root is the view of the filesystem that the target process
         // has. (see the proc man page for more)
         // So we read /usr/bin/ruby from /proc/PID/root/usr/bin/ruby
-        let map_path = map.pathname.as_ref().expect("map's pathname shouldn't be None");
+        let map_path = map.filename().as_ref().expect("map's pathname shouldn't be None");
         let elf_path = format!("/proc/{}/root{}", pid, map_path);
         elf::File::open_path(&elf_path)
             .map_err(|_| format_err!("Couldn't open ELF file: {:?}", elf_path))
     }
 
     pub fn get_program_info(pid: pid_t) -> Result<ProgramInfo, Error> {
-        let all_maps = get_proc_maps(pid).map_err(|x| match x.kind() {
+        let all_maps = get_process_maps(pid).map_err(|x| match x.kind() {
             std::io::ErrorKind::NotFound => AddressFinderError::NoSuchProcess(pid),
             std::io::ErrorKind::PermissionDenied => AddressFinderError::PermissionDenied(pid),
             _ => AddressFinderError::ProcMapsError(pid),
         })?;
-        let ruby_map = Box::new(get_map(&all_maps, "bin/ruby", "r-xp")
+        let ruby_map = Box::new(get_map(&all_maps, "bin/ruby")
             .ok_or(format_err!("Ruby map not found for PID: {}", pid))?);
-        let all_maps = get_proc_maps(pid).unwrap();
+        let all_maps = get_process_maps(pid).unwrap();
         let ruby_elf = open_elf_file(pid, &ruby_map)?;
-        let libruby_map = Box::new(get_map(&all_maps, "libruby", "r-xp"));
+        let libruby_map = Box::new(get_map(&all_maps, "libruby"));
         let libruby_elf = match *libruby_map {
             Some(ref map) => {
                 Some(open_elf_file(pid, &map)?)
@@ -353,11 +352,11 @@ mod os_impl {
         })
     }
 
-    fn get_map(maps: &Vec<MapRange>, contains: &str, flags: &str) -> Option<MapRange> {
+    fn get_map(maps: &[MapRange], contains: &str) -> Option<MapRange> {
         maps.iter()
             .find(|ref m| {
-                if let Some(ref pathname) = m.pathname {
-                    pathname.contains(contains) && &m.flags == flags
+                if let Some(ref pathname) = m.filename() {
+                    pathname.contains(contains) && m.is_exec()
                 } else {
                     false
                 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,7 +2,5 @@ pub mod types;
 pub mod initialize;
 mod address_finder;
 pub mod copy;
-#[cfg(target_os = "macos")]
-mod mac_maps;
 mod proc_maps;
 mod ruby_version;

--- a/src/core/proc_maps/linux_maps.rs
+++ b/src/core/proc_maps/linux_maps.rs
@@ -2,6 +2,7 @@ use libc;
 use std;
 use std::fs::File;
 use std::io::Read;
+use core::proc_maps::IMapRange;
 
 pub type Pid = libc::pid_t;
 
@@ -17,13 +18,13 @@ pub struct MapRange {
     pathname: Option<String>,
 }
 
-impl MapRange {
-    pub fn size(&self) -> usize { self.range_end - self.range_start }
-    pub fn start(&self) -> usize { self.range_start }
-    pub fn filename(&self) -> &Option<String> { &self.pathname }
-    pub fn is_exec(&self) -> bool { &self.flags[2..3] == "x" }
-    pub fn is_write(&self) -> bool { &self.flags[1..2] == "w" }
-    pub fn is_read(&self) -> bool { &self.flags[0..1] == "r" }
+impl IMapRange for MapRange {
+    fn size(&self) -> usize { self.range_end - self.range_start }
+    fn start(&self) -> usize { self.range_start }
+    fn filename(&self) -> &Option<String> { &self.pathname }
+    fn is_exec(&self) -> bool { &self.flags[2..3] == "x" }
+    fn is_write(&self) -> bool { &self.flags[1..2] == "w" }
+    fn is_read(&self) -> bool { &self.flags[0..1] == "r" }
 }
 
 pub fn get_process_maps(pid: Pid) -> std::io::Result<Vec<MapRange>> {

--- a/src/core/proc_maps/mac_maps.rs
+++ b/src/core/proc_maps/mac_maps.rs
@@ -13,13 +13,15 @@ use mach::types::vm_task_entry_t;
 use libproc::libproc::proc_pid::regionfilename;
 use mach;
 
+pub type Pid = pid_t;
+
 #[derive(Debug, Clone)]
-pub struct MacMapRange {
-    pub size: mach_vm_size_t,
-    pub info: vm_region_basic_info_data_t,
-    pub start: mach_vm_address_t,
-    pub count: mach_msg_type_number_t,
-    pub filename: Option<String>,
+pub struct MapRange {
+    size: mach_vm_size_t,
+    info: vm_region_basic_info_data_t,
+    start: mach_vm_address_t,
+    count: mach_msg_type_number_t,
+    filename: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -59,7 +61,10 @@ pub fn get_symbols(filename: &str) -> Result<Vec<Symbol>, Error> {
     Ok(parse_nm_output(&String::from_utf8_lossy(&output.stdout)))
 }
 
-impl MacMapRange {
+impl MapRange {
+    pub fn size(&self) -> usize { self.size as usize }
+    pub fn start(&self) -> usize { self.start as usize }
+    pub fn filename(&self) -> &Option<String> { &self.filename }
     pub fn end(&self) -> mach_vm_address_t {
         self.start + self.size as mach_vm_address_t
     }
@@ -81,7 +86,8 @@ impl MacMapRange {
  * to get the first memory map in the process, pass the end of that memory map to get the second
  * memory map, etc.
  */
-pub fn get_process_maps(pid: pid_t, task: mach_port_name_t) -> Vec<MacMapRange> {
+pub fn get_process_maps(pid: Pid) -> io::Result<Vec<MapRange>> {
+    let task = task_for_pid(pid)?;
     let init_region = mach_vm_region(pid, task, 1).unwrap();
     let mut vec = vec![];
     let mut region = init_region.clone();
@@ -92,16 +98,16 @@ pub fn get_process_maps(pid: pid_t, task: mach_port_name_t) -> Vec<MacMapRange> 
                 vec.push(r.clone());
                 region = r;
             }
-            _ => return vec,
+            _ => return Ok(vec),
         }
     }
 }
 
 fn mach_vm_region(
-    pid: pid_t,
+    pid: Pid,
     target_task: mach_port_name_t,
     mut address: mach_vm_address_t,
-) -> Option<MacMapRange> {
+) -> Option<MapRange> {
     let mut count = mem::size_of::<vm_region_basic_info_data_64_t>() as mach_msg_type_number_t;
     let mut object_name: mach_port_t = 0;
     let mut size = unsafe { mem::zeroed::<mach_vm_size_t>() };
@@ -124,16 +130,10 @@ fn mach_vm_region(
         Ok(x) => Some(x),
         _ => None,
     };
-    Some(MacMapRange {
-        size: size,
-        info: info,
-        start: address,
-        count: count,
-        filename: filename,
-    })
+    Some(MapRange{size, info, start: address, count, filename})
 }
 
-pub fn task_for_pid(pid: pid_t) -> io::Result<mach_port_name_t> {
+pub fn task_for_pid(pid: Pid) -> io::Result<mach_port_name_t> {
     let mut task: mach_port_name_t = MACH_PORT_NULL;
     // sleep for 10ms to make sure we don't get into a race between `task_for_pid` and execing a new
     // process. Races here can freeze the OS because of a Mac kernel bug on High Sierra.

--- a/src/core/proc_maps/mod.rs
+++ b/src/core/proc_maps/mod.rs
@@ -1,0 +1,18 @@
+#[cfg(target_os = "macos")]
+pub mod mac_maps;
+#[cfg(target_os = "macos")]
+pub use self::mac_maps::{get_process_maps, MapRange, Pid};
+
+#[cfg(target_os = "linux")]
+pub mod linux_maps;
+#[cfg(target_os = "linux")]
+pub use self::linux_maps::{get_process_maps, MapRange, Pid};
+
+fn map_contain_addr(map: &MapRange, addr: usize) -> bool {
+    let start = map.start();
+    (addr > start) && (addr < (start + map.size()))
+}
+
+pub fn maps_contain_addr(addr: usize, maps: &[MapRange]) -> bool {
+    maps.iter().any({ |map| map_contain_addr(map, addr) })
+}

--- a/src/core/proc_maps/mod.rs
+++ b/src/core/proc_maps/mod.rs
@@ -1,3 +1,12 @@
+pub trait IMapRange {
+    fn size(&self) -> usize;
+    fn start(&self) -> usize;
+    fn filename(&self) -> &Option<String>;
+    fn is_read(&self) -> bool;
+    fn is_write(&self) -> bool;
+    fn is_exec(&self) -> bool;
+}
+
 #[cfg(target_os = "macos")]
 pub mod mac_maps;
 #[cfg(target_os = "macos")]

--- a/src/core/ruby_version.rs
+++ b/src/core/ruby_version.rs
@@ -298,7 +298,7 @@ macro_rules! get_stack_frame_1_9_1(
             Ok(StackFrame{
                 name: get_ruby_string(iseq_struct.name as usize, source)?,
                 relative_path: get_ruby_string(iseq_struct.filename as usize, source)?,
-                absolute_path: None, 
+                absolute_path: None,
                 lineno: get_lineno(iseq_struct, cfp, source)?,
             })
         }


### PR DESCRIPTION
This code pulls out proc_maps/mac_maps into a submodule - and attempts to have
them present a unified interface.

Each OS version exposes a MapRange struct and get_process_maps function. The
get_process_maps function has the same signature for both linux and OSX, and
the MapRange struct exposes the same getter methods, with the idea that you
can use them identically across operating systems.