### PR TITLE
Make the --input and --output arguments to rbspy report mandatory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -682,8 +682,8 @@ fn arg_parser() -> App<'static, 'static> {
         .subcommand(
             SubCommand::with_name("report")
                 .about("Generate visualization from raw data recorded by `rbspy record`")
-                .arg(Arg::from_usage("-i --input=[FILE] 'Input raw data to use'"))
-                .arg(Arg::from_usage("-o --output=[FILE] 'Output file'"))
+                .arg(Arg::from_usage("-i --input=<FILE> 'Input raw data to use'"))
+                .arg(Arg::from_usage("-o --output=<FILE> 'Output file'"))
                 .arg(
                     Arg::from_usage("-f --format=[FORMAT] 'Output format to write'")
                         .possible_values(&OutputFormat::variants())
@@ -935,5 +935,22 @@ mod tests {
                 }
             );
         }
+    }
+
+    #[test]
+    fn test_report_arg_parsing() {
+        let args = Args::from(make_args(
+            "rbspy report --input xyz.raw.gz --output xyz",
+        )).unwrap();
+        assert_eq!(
+            args,
+            Args {
+                cmd: Report {
+                    format: OutputFormat::flamegraph,
+                    input: PathBuf::from("xyz.raw.gz"),
+                    output: PathBuf::from("xyz"),
+                },
+            }
+        );
     }
 }


### PR DESCRIPTION
Since there are no defaults for the `--input` and `--output` arguments of `rbspy report`, an error was returned when accessing them through `value_t!`, which was then unwrapped:

    thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { message: "\u{1b}[1;31merror:\u{1b}[0m The argument \'output\' wasn\'t found", kind: ArgumentNotFound, info: Some(["output"]) }', libcore/result.rs:945:5

Making them mandatory causes clap to exit when first parsing the arguments, which aligns with how other mandatory arguments are being handled. I tried to add a test for the error handling, but since currently `Args::from` exits the process when it can't parse the arguments it would have taken more refactoring. I think there's a pretty low chance of regression here anyway, so I've just added a basic CLI parsing test for the report subcommand. 