### PR TITLE
Build fixes for 32 bit windows

### DIFF
--- a/ruby-structs/src/ruby_1_9_1_0.rs
+++ b/ruby-structs/src/ruby_1_9_1_0.rs
@@ -1120,12 +1120,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1141,7 +1141,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_1_9_2_0.rs
+++ b/ruby-structs/src/ruby_1_9_2_0.rs
@@ -1136,12 +1136,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1157,7 +1157,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_1_9_3_0.rs
+++ b/ruby-structs/src/ruby_1_9_3_0.rs
@@ -1138,12 +1138,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1159,7 +1159,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_0_0_0.rs
+++ b/ruby-structs/src/ruby_2_0_0_0.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_1_0.rs
+++ b/ruby-structs/src/ruby_2_1_0.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_1_1.rs
+++ b/ruby-structs/src/ruby_2_1_1.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_1_10.rs
+++ b/ruby-structs/src/ruby_2_1_10.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_1_2.rs
+++ b/ruby-structs/src/ruby_2_1_2.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_1_3.rs
+++ b/ruby-structs/src/ruby_2_1_3.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_1_4.rs
+++ b/ruby-structs/src/ruby_2_1_4.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_1_5.rs
+++ b/ruby-structs/src/ruby_2_1_5.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_1_6.rs
+++ b/ruby-structs/src/ruby_2_1_6.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_1_7.rs
+++ b/ruby-structs/src/ruby_2_1_7.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_1_8.rs
+++ b/ruby-structs/src/ruby_2_1_8.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_1_9.rs
+++ b/ruby-structs/src/ruby_2_1_9.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_2_0.rs
+++ b/ruby-structs/src/ruby_2_2_0.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_2_1.rs
+++ b/ruby-structs/src/ruby_2_2_1.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_2_10.rs
+++ b/ruby-structs/src/ruby_2_2_10.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_2_2.rs
+++ b/ruby-structs/src/ruby_2_2_2.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_2_3.rs
+++ b/ruby-structs/src/ruby_2_2_3.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_2_4.rs
+++ b/ruby-structs/src/ruby_2_2_4.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_2_5.rs
+++ b/ruby-structs/src/ruby_2_2_5.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_2_6.rs
+++ b/ruby-structs/src/ruby_2_2_6.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_2_7.rs
+++ b/ruby-structs/src/ruby_2_2_7.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_2_8.rs
+++ b/ruby-structs/src/ruby_2_2_8.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_2_9.rs
+++ b/ruby-structs/src/ruby_2_2_9.rs
@@ -1282,12 +1282,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1303,7 +1303,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_3_0.rs
+++ b/ruby-structs/src/ruby_2_3_0.rs
@@ -1263,12 +1263,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1284,7 +1284,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_3_1.rs
+++ b/ruby-structs/src/ruby_2_3_1.rs
@@ -1263,12 +1263,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1284,7 +1284,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_3_2.rs
+++ b/ruby-structs/src/ruby_2_3_2.rs
@@ -1263,12 +1263,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1284,7 +1284,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_3_3.rs
+++ b/ruby-structs/src/ruby_2_3_3.rs
@@ -1263,12 +1263,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1284,7 +1284,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_3_4.rs
+++ b/ruby-structs/src/ruby_2_3_4.rs
@@ -1263,12 +1263,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1284,7 +1284,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_3_5.rs
+++ b/ruby-structs/src/ruby_2_3_5.rs
@@ -1263,12 +1263,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1284,7 +1284,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_3_6.rs
+++ b/ruby-structs/src/ruby_2_3_6.rs
@@ -1263,12 +1263,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1284,7 +1284,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/ruby-structs/src/ruby_2_3_7.rs
+++ b/ruby-structs/src/ruby_2_3_7.rs
@@ -1263,12 +1263,12 @@ impl st_table {
     }
     #[inline]
     pub fn num_entries(&self) -> st_index_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 63u8) as usize) }
     }
     #[inline]
     pub fn set_num_entries(&mut self, val: st_index_t) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: usize = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 63u8, val as u64)
         }
     }
@@ -1284,7 +1284,7 @@ impl st_table {
             entries_packed as u64
         });
         __bindgen_bitfield_unit.set(1usize, 63u8, {
-            let num_entries: u64 = unsafe { ::std::mem::transmute(num_entries) };
+            let num_entries: usize = unsafe { ::std::mem::transmute(num_entries) };
             num_entries as u64
         });
         __bindgen_bitfield_unit

--- a/scripts/bindgen.sh
+++ b/scripts/bindgen.sh
@@ -44,3 +44,6 @@ cat /tmp/bindings.rs >> $OUT
 
 # fix up generated bindings so that they compile/work on windows
 perl -pi -e "s/::std::os::raw::c_ulong;/usize;/g" $OUT
+perl -pi -e "s/63u8\) as u64/63u8\) as usize/g" $OUT
+perl -pi -e "s/let val: u64 =/let val: usize =/g" $OUT
+perl -pi -e "s/let num_entries: u64 =/let num_entries: usize =/g" $OUT


### PR DESCRIPTION
This changes the generated ruby-structs so that they compile on 32 bit toolchains.
This lets rbspy build on the i686-pc-windows-msvc toolchain and profile 32 bit Ruby
versions on windows. 