### PR TITLE
Handle process exitting on Windows

### DIFF
--- a/src/core/copy.rs
+++ b/src/core/copy.rs
@@ -50,6 +50,10 @@ where
         } else if x.raw_os_error() == Some(60) {
             // On Mac code 60 seems to more or less correspond to "process ended"
             MemoryCopyError::ProcessEnded
+        } else if x.raw_os_error() == Some(299) {
+            // On Windows code 299 seems to only happen when the process ended
+            // (though technically indicates only part of the copy succeeded)
+            MemoryCopyError::ProcessEnded
         } else if x.kind() == std::io::ErrorKind::PermissionDenied {
             MemoryCopyError::PermissionDenied
         } else {


### PR DESCRIPTION
When the profiled process on Windows exits, there is usually a [299 error code returned](https://docs.microsoft.com/en-us/windows/desktop/debug/system-error-codes--0-499-#error_partial_copy)
from the read_process_memory call. Treat this like the process exitted.