### PR TITLE
Sample thread_ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "rbspy"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -24,6 +24,7 @@ pub struct StackFrame {
 pub struct StackTrace {
     pub trace: Vec<StackFrame>,
     pub pid: Option<pid_t>,
+    pub thread_id: Option<usize>,
 }
 
 pub struct Process<T> where T: CopyAddress {

--- a/src/storage/v0.rs
+++ b/src/storage/v0.rs
@@ -33,6 +33,6 @@ impl From<Data> for v1::Data {
 
 impl From<Vec<StackFrame>> for StackTrace {
     fn from(trace: Vec<StackFrame>) -> StackTrace {
-        StackTrace{pid: None, trace}
+        StackTrace{pid: None, trace, thread_id: None}
     }
 }


### PR DESCRIPTION
We want to use `rbspy` as a profiler engine for RubyMine. It turned out it turned out that dividing samples not only by pids but by thread_id quite usefull. As in the case of rails for example some threads are always loop some library code, such threads add some noise to a flame graph with mixed thread. In addition, it allows user to better localize the problem, as only the flamegraph of the desired thread is considered (with the needed method, for example)

![screenshot from 2019-02-04 22-15-37](https://user-images.githubusercontent.com/6137315/52231230-769cc080-28ca-11e9-87cf-565e3d6e9c13.png)
