### PR TITLE
Add --silent flag, which allows to cancel every second logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "rbspy"
-version = "0.3.3"
+version = "0.3.5"
 dependencies = [
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbspy"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Julia Evans <julia@jvns.ca>"]
 description = "Sampling CPU profiler for Ruby"
 keywords = ["ruby", "profiler", "MRI"]


### PR DESCRIPTION
As we discussed in https://github.com/rbspy/rbspy/pull/199, sometimes it is needed to turn off the logging of the profiler's summary data.

P.S Can you please release the latest rpspy version, so we can share a link to it?