### PR TITLE
Fix "warning: unused `std::result::Result` that must be used"

### DIFF
--- a/src/ui/flamegraph.rs
+++ b/src/ui/flamegraph.rs
@@ -65,20 +65,22 @@ mod tests {
     }
 
     #[test]
-    fn test_stats() {
+    fn test_stats() -> Result<(), io::Error> {
         let mut stats = Stats::new();
 
-        stats.record(&vec![f(1)]);
-        stats.record(&vec![f(2), f(1)]);
-        stats.record(&vec![f(2), f(1)]);
-        stats.record(&vec![f(2), f(3), f(1)]);
-        stats.record(&vec![f(2), f(3), f(1)]);
-        stats.record(&vec![f(2), f(3), f(1)]);
+        stats.record(&vec![f(1)])?;
+        stats.record(&vec![f(2), f(1)])?;
+        stats.record(&vec![f(2), f(1)])?;
+        stats.record(&vec![f(2), f(3), f(1)])?;
+        stats.record(&vec![f(2), f(3), f(1)])?;
+        stats.record(&vec![f(2), f(3), f(1)])?;
 
         let counts = &stats.counts;
         assert_contains(counts, "func1 - file1.rb line 1;", 1);
         assert_contains(counts, "func1 - file1.rb line 1;func3 - file3.rb line 3;func2 - file2.rb line 2;", 3);
         assert_contains(counts, "func1 - file1.rb line 1;func2 - file2.rb line 2;", 2);
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Since Rust 1.28.0, unit tests can return Result.