### PR TITLE
Small fixes for scripts/bindgen.sh

### DIFF
--- a/scripts/bindgen.sh
+++ b/scripts/bindgen.sh
@@ -8,6 +8,8 @@ if [ ! -d "$ruby_src_dir" ]; then
    exit 1
 fi
 
+ruby_header_dir="$(ruby -rrbconfig -e 'puts RbConfig::CONFIG["rubyarchhdrdir"]')"
+
 echo "#include </tmp/headers/$1/vm_core.h>" > /tmp/wrapper.h
 echo "#include </tmp/headers/$1/iseq.h>" >> /tmp/wrapper.h
 rm -rf /tmp/headers/$1
@@ -41,7 +43,8 @@ bindgen /tmp/wrapper.h \
     -- \
     -I/tmp/headers/$1/include \
     -I/home/bork/monorepo/ruby-header-files -I/tmp/headers/$1/ \
-    -I/usr/lib/llvm-3.8/lib/clang/3.8.0/include/
+    -I/usr/lib/llvm-3.8/lib/clang/3.8.0/include/ \
+    "-I$ruby_header_dir"
 
 #rustfmt --force src/bindings/ruby_${1}.rs
 

--- a/scripts/bindgen.sh
+++ b/scripts/bindgen.sh
@@ -24,7 +24,7 @@ cp "$ruby_src_dir"/*.h /tmp/headers/$1
 OUT=ruby-structs/src/ruby_${1}.rs
 bindgen /tmp/wrapper.h \
     -o /tmp/bindings.rs \
-    --impl-debug true \
+    --impl-debug \
     --no-doc-comments \
     --whitelist-type rb_iseq_constant_body \
     --whitelist-type rb_iseq_location_struct \


### PR DESCRIPTION
I was able to run `sh ./scripts/bindgen.sh 2_6_2` on my MacBook, then realized that all bindgen-generated files were apparently generated on Linux (my ruby_2_6_2.rs mentions "darwin" here and there...). So, I don't include the .rs file on this pull request.
