### PR TITLE
[#189] Implement --subprocesses on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ nix = "0.13.0"
 libproc = "0.4.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["timeapi"] }
+winapi = { version = "0.3", features = ["timeapi", "wow64apiset"] }
 
 [dev-dependencies]
 byteorder = "1.3.1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,9 +39,11 @@ environment:
   # Stable 64-bit MSVC
     - channel: stable
       target: x86_64-pc-windows-msvc
+      RUBY_VERSION: 25-x64
   # Stable 32-bit MSVC
     - channel: stable
       target: i686-pc-windows-msvc
+      RUBY_VERSION: 25
 
 ## Install Script ##
 
@@ -54,7 +56,8 @@ environment:
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %target%
-  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%;%USERPROFILE%\.cargo\bin
+  - ruby -v
   - rustc -vV
   - cargo -vV
 

--- a/ci/ruby-programs/ruby_forks.rb
+++ b/ci/ruby-programs/ruby_forks.rb
@@ -1,11 +1,17 @@
 SLEEP_TIME = 2
 
-pid1 = fork do
-  pid1_1 = fork { sleep SLEEP_TIME }
+suprocess_cmd = <<-CMD
+  pid1_1 = spawn(ENV, RbConfig.ruby, "-esleep(#{SLEEP_TIME})")
 
-  sleep SLEEP_TIME
-end
+  sleep #{SLEEP_TIME}
+  Process.wait(pid1_1)
+CMD
 
-pid2 = fork { sleep SLEEP_TIME }
+pid1 = spawn(ENV, RbConfig.ruby, "-e#{suprocess_cmd}")
+
+pid2 = spawn(ENV, RbConfig.ruby, "-esleep(#{SLEEP_TIME})")
 
 sleep SLEEP_TIME
+
+Process.wait(pid1)
+Process.wait(pid2)


### PR DESCRIPTION
Tracing subprocesses is not possible on Microsoft Windows, yet.

This change
* Implements `get_proc_children()` function for Windows, using
  `NtGetNextProcess` function. `NtGetNextProcess` is an undocumented
  routine of ntdll, but this approach is said to perform better than
  Process32First/Process32Next.
* Enables `--subprocesses` option for Windows.
* Refactors ruby_forks testing script to use `Kernel#spawn` instead of
  `#Kernel#fork`, because the latter isn't supported in Windows'
  Ruby.