### PR TITLE
Fix fidelity of flamegraph SVGs

### DIFF
--- a/src/ui/flamegraph.rs
+++ b/src/ui/flamegraph.rs
@@ -32,7 +32,6 @@ impl Stats {
 
         let mut opts =  Options {
             direction: Direction::Inverted,
-            min_width: 2_f64,
             ..Default::default()
         };
 


### PR DESCRIPTION
The `min_width` went from being minimum pixels to percent of the graph width sometime from 0.7 -> 0.9.  Currently, using the default of 0.1% seems reasonable.

It think it would be worthwhile to consider allowing this and other options to be set from the CLI. Optionally, I think supporting a config file might be worthwhile too.

Fixes https://github.com/rbspy/rbspy/issues/239