### PR TITLE
Allow merging multiple reports together

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "rbspy"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -10,7 +10,7 @@ use failure::Context;
 pub use remoteprocess::{Error, Process, Pid, ProcessMemory};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
-pub(crate) struct Header {
+pub struct Header {
     pub sample_rate: Option<u32>,
     pub rbspy_version: Option<String>,
     pub start_time: Option<SystemTime>,

--- a/src/storage/v0.rs
+++ b/src/storage/v0.rs
@@ -19,6 +19,11 @@ impl Storage for Data {
         }
         Ok(Data(result))
     }
+
+    fn append(mut self, rhs: Self) -> Result<Data, Error> {
+      unimplemented!();
+    }
+
     fn version() -> Version {
         Version(0)
     }

--- a/src/storage/v1.rs
+++ b/src/storage/v1.rs
@@ -19,6 +19,11 @@ impl Storage for Data {
         }
         Ok(Data(result))
     }
+
+    fn append(mut self, r: Self) -> Result<Data, Error> {
+      unimplemented!();
+    }
+
     fn version() -> Version {
         Version(1)
     }

--- a/src/storage/v2.rs
+++ b/src/storage/v2.rs
@@ -18,15 +18,41 @@ impl Storage for Data {
         let mut result = Vec::new();
         let mut lines = reader.lines();
         let mut header_line = lines.next().unwrap().unwrap();
+
         for line in lines {
             let trace: StackTrace = serde_json::from_str(&line?)?;
             result.push(trace);
         }
+
         Ok(Data {
             header: serde_json::from_str(&header_line)?,
             traces: result,
         })
     }
+
+    fn append(mut self, mut rhs: Self) -> Result<Data, Error> {
+        let sample_rate = if self.header.sample_rate == rhs.header.sample_rate {
+            self.header.sample_rate
+        } else {
+            None
+        };
+
+        let rbspy_version = if self.header.rbspy_version == rhs.header.rbspy_version {
+            self.header.rbspy_version.clone()
+        } else {
+            None
+        };
+
+        self.header = Header {
+            sample_rate: sample_rate,
+            rbspy_version: rbspy_version,
+            start_time: None
+        };
+        self.traces.append(&mut rhs.traces);
+
+        Ok(self)
+    }
+
     fn version() -> Version {
         Version(2)
     }

--- a/src/ui/output.rs
+++ b/src/ui/output.rs
@@ -84,6 +84,18 @@ impl Outputter for Speedscope {
     }
 }
 
+pub struct NoStats;
+
+impl Outputter for NoStats {
+    fn record(&mut self, _stack: &StackTrace) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn complete(&mut self, _file: File) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
 /// Filter out unknown functions from stack trace before reporting.
 /// Most of the time it isn't useful to include the "unknown C function" stacks.
 fn filter_unknown(trace: &[StackFrame]) -> Vec<StackFrame> {


### PR DESCRIPTION
This changes `rbspy report` subcommand:
* Allow multiple inputs to be specified with `-i`.
* Add `-m` flag to allow merging multiple inputs into one output. 
* Let `-o` for output be optional. 
  - It automatically applies a default name: 
    * When merging, this defaults to `"merged" + extension`.
    * Without merging, it takes the root from the input it is processing. 
  - Output filename does not require extension being supplied.

This changes `rbspy record` subcommand:
* Both `--raw-file /tmp/raw` and `--raw-file /tmp/raw.raw.gz` will set the filename to `raw.raw.gz`.
* It will fix extensions for formats: `--file flamegraph.txt --format flamegraph` will set filename to `flamegraph.svg`. No supplied will append it correctly.
* `--format raw` will only output the raw file. This avoids the post processing step that can be more cpu expensive when left running long enough at a high enough rate.


 Testing:
- [x] Some manual testing.
- [x] Merged report.
- [x] Multiple reports and multiple outputs.
