### PR TITLE
Include sample timestamps in file format

### DIFF
--- a/src/core/ruby_version.rs
+++ b/src/core/ruby_version.rs
@@ -159,7 +159,8 @@ macro_rules! get_stack_trace(
                 return Ok(StackTrace {
                     pid: None,
                     trace: vec!(StackFrame::unknown_c_function()),
-                    thread_id: Some(get_thread_id(&thread, source)?)
+                    thread_id: Some(get_thread_id(&thread, source)?),
+                    time: Some(SystemTime::now())
                 });
             }
             let mut trace = Vec::new();
@@ -201,10 +202,11 @@ macro_rules! get_stack_trace(
                     }
                 }
             }
-            Ok(StackTrace{trace, pid: None, thread_id: Some(get_thread_id(&thread, source)?)})
+            Ok(StackTrace{trace, pid: None, thread_id: Some(get_thread_id(&thread, source)?), time: Some(SystemTime::now())})
         }
 
 use proc_maps::{maps_contain_addr, MapRange};
+use std::time::SystemTime;
 
 // Checks whether the address looks even vaguely like a thread struct, mostly by making sure its
 // addresses are reasonable

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -3,6 +3,7 @@
 use std::cmp::Ordering;
 use std::fmt;
 use std::{self, convert::From};
+use std::time::SystemTime;
 
 use failure::Context;
 
@@ -21,6 +22,7 @@ pub struct StackTrace {
     pub trace: Vec<StackFrame>,
     pub pid: Option<Pid>,
     pub thread_id: Option<usize>,
+    pub time: Option<SystemTime>,
 }
 
 #[derive(Fail, Debug)]

--- a/src/storage/v0.rs
+++ b/src/storage/v0.rs
@@ -33,6 +33,6 @@ impl From<Data> for v1::Data {
 
 impl From<Vec<StackFrame>> for StackTrace {
     fn from(trace: Vec<StackFrame>) -> StackTrace {
-        StackTrace{pid: None, trace, thread_id: None}
+        StackTrace{pid: None, trace, thread_id: None, time: None}
     }
 }


### PR DESCRIPTION
This patch adds timestamps to the ndjson file format emitted by rbspy.

This is useful for tools that take time into account, including speedscope (https://github.com/rbspy/rbspy/pull/161), google [cloud profiler](https://cloud.google.com/profiler/) (for continuous profiling), and [flamescope](https://github.com/Netflix/flamescope).

A sample line:

```
{"trace":[{"name":"<c function>","relative_path":"unknown","absolute_path":null,"lineno":0},{"name":"<c function>","relative_path":"unknown","absolute_path":null,"lineno":0},{"name":"block (2 levels) in spawn_thread","relative_path":"/opt/gitlab/embedded/lib/ruby/gems/2.6.0/gems/gitlab-puma-4.3.3.gitlab.2/lib/puma/thread_pool.rb","absolute_path":"/opt/gitlab/embedded/lib/ruby/gems/2.6.0/gems/gitlab-puma-4.3.3.gitlab.2/lib/puma/thread_pool.rb","lineno":129},{"name":"<c function>","relative_path":"unknown","absolute_path":null,"lineno":0},{"name":"block in spawn_thread","relative_path":"/opt/gitlab/embedded/lib/ruby/gems/2.6.0/gems/gitlab-puma-4.3.3.gitlab.2/lib/puma/thread_pool.rb","absolute_path":"/opt/gitlab/embedded/lib/ruby/gems/2.6.0/gems/gitlab-puma-4.3.3.gitlab.2/lib/puma/thread_pool.rb","lineno":148}],"pid":3881,"thread_id":140651886802688,"time":{"secs_since_epoch":1585847714,"nanos_since_epoch":884414700}}
```

New addition:

```
"time":{"secs_since_epoch":1585847714,"nanos_since_epoch":884414700}
```

It currently emits `secs_since_epoch` and `nanos_since_epoch` fields from rust's [`std::time:SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html). Though I'd be happy to make adjustments if needed!

I didn't bump the file format version, since this addition of a new key is backwards-compatible as far as I can tell.

fixes #162