### PR TITLE
add header line to storage format, storing sample rate

### DIFF
--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -11,7 +11,7 @@ pub use remoteprocess::{Error, Process, Pid, ProcessMemory};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub(crate) struct Header {
-    pub hz: Option<u32>,
+    pub sample_rate: Option<u32>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -12,6 +12,8 @@ pub use remoteprocess::{Error, Process, Pid, ProcessMemory};
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub(crate) struct Header {
     pub sample_rate: Option<u32>,
+    pub rbspy_version: Option<String>,
+    pub start_time: Option<SystemTime>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -9,6 +9,11 @@ use failure::Context;
 pub use remoteprocess::{Error, Process, Pid, ProcessMemory};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub(crate) struct Header {
+    pub hz: Option<u32>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct StackFrame {
     pub name: String,
     pub relative_path: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -520,7 +520,7 @@ fn parallel_record(
     // and the formatted output (a flamegraph or something)
     let mut out = format.outputter();
     let mut summary_out = ui::summary::Stats::new();
-    let mut raw_store = storage::Store::new(raw_path)?;
+    let mut raw_store = storage::Store::new(raw_path, sample_rate)?;
     let mut summary_time = std::time::Instant::now() + Duration::from_secs(1);
     let start_time = Instant::now();
 
@@ -639,7 +639,7 @@ fn record(
 
 fn report(format: OutputFormat, input: PathBuf, output: PathBuf) -> Result<(), Error>{
     let input_file = File::open(input)?;
-    let stuff = storage::from_reader(input_file)?.0;
+    let stuff = storage::from_reader(input_file)?.traces;
     let mut outputter = format.outputter();
     for trace in stuff {
         outputter.record(&trace)?;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -50,8 +50,6 @@ impl Store {
     pub fn write(&mut self, trace: &StackTrace) -> Result<(), Error> {
         let json = serde_json::to_string(trace)?;
         writeln!(&mut self.encoder, "{}", json)?;
-        let json = serde_json::to_string(trace)?;
-        writeln!(&mut self.encoder, "{}", json)?;
         Ok(())
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -17,6 +17,7 @@ use std::io;
 use std::io::prelude::*;
 use std::fs::File;
 use std::path::Path;
+use std::time::SystemTime;
 
 use crate::core::types::Header;
 use crate::core::types::StackTrace;
@@ -41,6 +42,8 @@ impl Store {
 
         let json = serde_json::to_string(&Header {
             sample_rate: Some(sample_rate),
+            rbspy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            start_time: Some(SystemTime::now()),
         })?;
         writeln!(&mut encoder, "{}", json)?;
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -34,13 +34,13 @@ pub struct Store {
 }
 
 impl Store {
-    pub fn new(out_path: &Path, hz: u32) -> Result<Store, io::Error> {
+    pub fn new(out_path: &Path, sample_rate: u32) -> Result<Store, io::Error> {
         let file = File::create(out_path)?;
         let mut encoder = flate2::write::GzEncoder::new(file, Compression::default());
         encoder.write_all("rbspy02\n".as_bytes())?;
 
         let json = serde_json::to_string(&Header {
-            hz: Some(hz),
+            sample_rate: Some(sample_rate),
         })?;
         writeln!(&mut encoder, "{}", json)?;
 

--- a/src/storage/v0.rs
+++ b/src/storage/v0.rs
@@ -28,7 +28,7 @@ impl From<Data> for v2::Data {
     fn from(d: Data) -> v2::Data {
         let x: Vec<StackTrace> = d.0.into_iter().map(std::convert::Into::into).collect();
         v2::Data {
-            header: Header {hz: None},
+            header: Header {sample_rate: None},
             traces: x,
         }
     }

--- a/src/storage/v0.rs
+++ b/src/storage/v0.rs
@@ -1,6 +1,6 @@
 use std::io::prelude::*;
 use std::io::BufReader;
-use crate::core::types::{StackTrace, StackFrame};
+use crate::core::types::{Header, StackTrace, StackFrame};
 
 use failure::Error;
 use serde_json;
@@ -24,10 +24,13 @@ impl Storage for Data {
     }
 }
 
-impl From<Data> for v1::Data {
-    fn from(d: Data) -> v1::Data {
+impl From<Data> for v2::Data {
+    fn from(d: Data) -> v2::Data {
         let x: Vec<StackTrace> = d.0.into_iter().map(std::convert::Into::into).collect();
-        v1::Data(x)
+        v2::Data {
+            header: Header {hz: None},
+            traces: x,
+        }
     }
 }
 

--- a/src/storage/v0.rs
+++ b/src/storage/v0.rs
@@ -28,7 +28,11 @@ impl From<Data> for v2::Data {
     fn from(d: Data) -> v2::Data {
         let x: Vec<StackTrace> = d.0.into_iter().map(std::convert::Into::into).collect();
         v2::Data {
-            header: Header {sample_rate: None},
+            header: Header {
+                sample_rate: None,
+                rbspy_version: None,
+                start_time: None,
+            },
             traces: x,
         }
     }

--- a/src/storage/v1.rs
+++ b/src/storage/v1.rs
@@ -27,7 +27,11 @@ impl Storage for Data {
 impl From<Data> for v2::Data {
     fn from(d: Data) -> v2::Data {
         v2::Data {
-            header: Header {sample_rate: None},
+            header: Header {
+                sample_rate: None,
+                rbspy_version: None,
+                start_time: None,
+            },
             traces: d.0,
         }
     }

--- a/src/storage/v1.rs
+++ b/src/storage/v1.rs
@@ -27,7 +27,7 @@ impl Storage for Data {
 impl From<Data> for v2::Data {
     fn from(d: Data) -> v2::Data {
         v2::Data {
-            header: Header {hz: None},
+            header: Header {sample_rate: None},
             traces: d.0,
         }
     }


### PR DESCRIPTION
This is another approach to addressing https://github.com/rbspy/rbspy/issues/162. Potentially it would be useful to have both.

By storing the sample frequency, it's possible to infer approximately how much time a function spent on the stack.

This change requires a bump in the format version, since there is now a "header" line after the `rbspy02\n` line.

Sample output:

```
rbspy02
{"sample_rate":100,"rbspy_version":"0.3.8","start_time":{"secs_since_epoch":1586161110,"nanos_since_epoch":410485101}}
{"trace":[{"name":"<c function>","relative_path":"unknown","absolute_path":null,"lineno":0},{"name":"handle_servers","relative_path":"/opt/gitlab/embedded/lib/ruby/gems/2.6.0/gems/gitlab-puma-4.3.3.gitlab.2/lib/puma/server.rb","absolute_path":"/opt/gitlab/embedded/lib/ruby/gems/2.6.0/gems/gitlab-puma-4.3.3.gitlab.2/lib/puma/server.rb","lineno":445},{"name":"block in run","relative_path":"/opt/gitlab/embedded/lib/ruby/gems/2.6.0/gems/gitlab-puma-4.3.3.gitlab.2/lib/puma/server.rb","absolute_path":"/opt/gitlab/embedded/lib/ruby/gems/2.6.0/gems/gitlab-puma-4.3.3.gitlab.2/lib/puma/server.rb","lineno":364}],"pid":23071,"thread_id":140428353464064}
...
```

Header line:

```
{"sample_rate":100,"rbspy_version":"0.3.8","start_time":{"secs_since_epoch":1586161110,"nanos_since_epoch":410485101}}
```

It's intentionally using `Option` so that new header fields can be added in the future without having to change the format.

Some useful things that could be added:

* cli args
* ruby version
* hostname