### PR TITLE
Add support for flamegraph intermediate output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,7 @@ arg_enum!{
     #[allow(non_camel_case_types)]
     pub enum OutputFormat {
         flamegraph,
+        flamegraph_stack_lines,
         callgrind,
         speedscope,
         summary,
@@ -301,6 +302,7 @@ impl OutputFormat {
     fn outputter(self) -> Box<dyn ui::output::Outputter> {
         match self {
             OutputFormat::flamegraph => Box::new(output::Flamegraph(ui::flamegraph::Stats::new())),
+            OutputFormat::flamegraph_stack_lines => Box::new(output::FlamegraphStackLines(ui::flamegraph::Stats::new())),
             OutputFormat::callgrind => Box::new(output::Callgrind(ui::callgrind::Stats::new())),
             OutputFormat::speedscope => Box::new(output::Speedscope(ui::speedscope::Stats::new())),
             OutputFormat::summary => Box::new(output::Summary(ui::summary::Stats::new())),
@@ -311,6 +313,7 @@ impl OutputFormat {
     fn extension(&self) -> String {
         match *self {
             OutputFormat::flamegraph => "flamegraph.svg",
+            OutputFormat::flamegraph_stack_lines => "stack_lines.folded",
             OutputFormat::callgrind => "callgrind.txt",
             OutputFormat::speedscope => "speedscope.json",
             OutputFormat::summary => "summary.txt",

--- a/src/ui/flamegraph.rs
+++ b/src/ui/flamegraph.rs
@@ -28,15 +28,25 @@ impl Stats {
     }
 
     pub fn write(&self, w: File) -> Result<(), Error> {
-        let lines: Vec<String> = self.counts.iter().map(|(k, v)| format!("{} {}", k, v)).collect();
-
         let mut opts =  Options {
             direction: Direction::Inverted,
             ..Default::default()
         };
 
+        let lines = self.get_lines();
         inferno::flamegraph::from_lines(&mut opts, lines.iter().map(|x| x.as_str()), w).unwrap();
         Ok(())
+    }
+
+    pub fn write_stack_lines(&self, w: &mut dyn io::Write) -> Result<(), Error> {
+        for line in self.get_lines() {
+            writeln!(w, "{}", line)?;
+        }
+        Ok(())
+    }
+
+    fn get_lines(&self) -> Vec<String> {
+        self.counts.iter().map(|(k, v)| format!("{} {}", k, v)).collect()
     }
 }
 

--- a/src/ui/output.rs
+++ b/src/ui/output.rs
@@ -27,6 +27,20 @@ impl Outputter for Flamegraph {
     }
 }
 
+pub struct FlamegraphStackLines(pub flamegraph::Stats);
+
+impl Outputter for FlamegraphStackLines {
+    fn record(&mut self, stack: &StackTrace) -> Result<(), Error> {
+        self.0.record(&stack.trace)?;
+        Ok(())
+    }
+
+    fn complete(&mut self, mut file: File) -> Result<(), Error> {
+        self.0.write_stack_lines(&mut file)?;
+        Ok(())
+    }
+}
+
 pub struct Callgrind(pub callgrind::Stats);
 
 impl Outputter for Callgrind {


### PR DESCRIPTION
Add support for outputting trace data into the folded
format that can be turned into a flamegraph.svg by
flamegraph.pl/inferno-flamegraph/etc.

Testing... Lots of different opinions about when/how IO should be tested--wanted to check in before I went nuts writing integration tests. 