### PR TITLE
add Dockerfile for use with bindgen.sh

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:buster
+
+RUN apt-get update
+RUN apt-get install -y git ruby build-essential autoconf bison libssl-dev zlib1g-dev
+RUN apt-get install -y clang libclang-dev curl
+
+RUN git clone https://github.com/ruby/ruby.git ~/clones/ruby
+
+ENV RUBY_VERSION=2_7_2
+
+WORKDIR /root/clones/ruby
+RUN git checkout v${RUBY_VERSION}
+RUN autoconf
+RUN ./configure --disable-install-doc
+RUN make
+RUN make install
+
+RUN git clone https://github.com/rbspy/rbspy.git /opt/rbspy
+
+WORKDIR /opt/rbspy
+ENV PATH=~/clones/ruby:${PATH}
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2020-10-08
+RUN ~/.cargo/bin/cargo install bindgen
+ENV PATH=~/.cargo/bin:${PATH}
+
+COPY scripts/bindgen.sh /opt/rbspy/scripts/bindgen.sh
+
+CMD bash /opt/rbspy/scripts/bindgen.sh ${RUBY_VERSION}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ You will need to have forked/cloned this repo and have several things in order t
 
 ### Executing the script
 
-Once you have satisfied dependencies. You can run the script (NOTE: you must run the script from the root of the project) like with a single argument wich represents the version you are building for (in this case 2.5.8): 
+Once you have satisfied dependencies. You can run the script (NOTE: you must run the script from the root of the project) like with a single argument wich represents the version you are building for (in this case 2.5.8):
 
 ```
 ./scripts/bindgen.sh 2_5_8
@@ -22,3 +22,15 @@ Once you have satisfied dependencies. You can run the script (NOTE: you must run
 
 This should generate a file `ruby-structs/src/ruby_2_5_8.rs` with the updated bindings. Once you have this you can check it in as part of a PR to point to it (for example: https://github.com/rbspy/rbspy/pull/261)
 
+### Running the script via Docker
+
+There is also a Dockerfile that can be used to run bindgen for individual ruby versions.
+
+Here is an example of how to run it:
+
+```
+docker build -t rbspy-bindgen -f scripts/Dockerfile .
+docker run -v $(pwd)/ruby-structs:/opt/rbspy/ruby-structs rbspy-bindgen
+```
+
+You can patch the `RUBY_VERSION` in the Dockerfile to target different versions.

--- a/scripts/bindgen.sh
+++ b/scripts/bindgen.sh
@@ -46,7 +46,7 @@ bindgen /tmp/wrapper.h \
     -I/usr/lib/llvm-3.8/lib/clang/3.8.0/include/ \
     "-I$ruby_header_dir"
 
-#rustfmt --force src/bindings/ruby_${1}.rs
+rustfmt /tmp/bindings.rs
 
 echo "#![allow(non_upper_case_globals)]" > $OUT
 echo "#![allow(non_camel_case_types)]" >> $OUT


### PR DESCRIPTION
This allows you to run a bindgen in a relatively self-contained environment. Some hackery was needed to get it working, and it doesn't generate exactly the same files that exist in the repo, at least not yet. This is quite possibly due to differing bindgen versions, and possibly other updates in rust packages.

I had to go with an older debian version because older rubies require an older version of bison (https://bugs.ruby-lang.org/issues/17106).

I've opened a separate MR for `2_7_2`, which we don't have support for yet: https://github.com/rbspy/rbspy/pull/271.