### PR TITLE
Prepare v0.3.11 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "rbspy"
-version = "0.3.9"
+version = "0.3.11"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbspy"
-version = "0.3.10"
+version = "0.3.11"
 authors = ["Julia Evans <julia@jvns.ca>"]
 description = "Sampling CPU profiler for Ruby"
 keywords = ["ruby", "profiler", "MRI"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ running 1 simple command.
 
 `rbspy` lets you profile Ruby processes that are already running. You give it a PID, and it starts
 profiling. It's a sampling profiler, which means it's **low overhead** and **safe to run in
-production**. 
+production**.
 
 `rbspy` lets you record profiling data, save the raw profiling data to disk, and then analyze it in
 a variety of different ways later on.
@@ -18,7 +18,7 @@ a variety of different ways later on.
 ## only wall-clock profiling
 
 There are 2 main ways to profile code -- you can either profile everything the
-application does (including waiting), or only profile when the application is using the CPU. 
+application does (including waiting), or only profile when the application is using the CPU.
 
 rbspy profiles everything the program does (including waiting) -- there's no
 option to just profile when the program is using the CPU.
@@ -69,6 +69,15 @@ https://www.rust-lang.org/ has great resources for learning Rust.
 1. `cargo test` to test
 
 The built binary will end up at `target/debug/rbspy`
+
+## Tagging a release
+
+Here are the steps for maintainers to tag a new release:
+
+1. Update `Cargo.toml` with the new version, run `cargo build` to ensure `Cargo.lock` is updated.
+1. Open an MR for the version bump. You can generate a CHANGELOG via `git log --pretty='- %s' v0.3.10...HEAD`.
+1. After the MR was merged, tag the new release, e.g. `git tag v0.3.11`, and push it: `git push --tags`.
+1. Travis will publish the tarballs to GitHub.
 
 ## Contributors
 


### PR DESCRIPTION
Changelog:

- add support for ruby 2.4.10 and 2.5.2 (#272)
- add support for ruby 2.7.2, (#271)
- add timestamp weights to speedscope output format (#253)
- say that rbspy isn't an on-CPU profiler

I also added documentation for the release process, as per https://github.com/rbspy/rbspy/pull/272#issuecomment-723440469.