### PR TITLE
Add flamegraph precision option to control min_width

### DIFF
--- a/ci/ruby-programs/recurse-sleep.rb
+++ b/ci/ruby-programs/recurse-sleep.rb
@@ -1,0 +1,7 @@
+def recurse_sleep(seconds)
+  return if seconds <= 0.00001
+  sleep(seconds/2.0)
+  recurse_sleep(seconds/2.0)
+end
+
+recurse_sleep(30)

--- a/src/ui/flamegraph.rs
+++ b/src/ui/flamegraph.rs
@@ -10,11 +10,15 @@ use inferno::flamegraph::{Direction, Options};
 #[derive(Default)]
 pub struct Stats {
     pub counts: HashMap<String, usize>,
+    pub min_width: f64,
 }
 
 impl Stats {
-    pub fn new() -> Stats {
-        Default::default()
+    pub fn new(flamegraph_precision: u32) -> Stats {
+        Stats {
+            min_width: 1_f64/(flamegraph_precision as f64),
+            ..Default::default()
+        }
     }
 
     pub fn record(&mut self, stack: &[StackFrame]) -> Result<(), io::Error> {
@@ -31,6 +35,7 @@ impl Stats {
 
         let mut opts = Options::default();
         opts.direction = Direction::Inverted;
+        opts.min_width = self.min_width;
 
         inferno::flamegraph::from_lines(&mut opts, lines.iter().map(|x| x.as_str()), w).unwrap();
         Ok(())
@@ -57,7 +62,7 @@ mod tests {
 
     #[test]
     fn test_stats() -> Result<(), io::Error> {
-        let mut stats = Stats::new();
+        let mut stats = Stats::new(10);
 
         stats.record(&vec![f(1)])?;
         stats.record(&vec![f(2), f(1)])?;

--- a/src/ui/flamegraph.rs
+++ b/src/ui/flamegraph.rs
@@ -14,9 +14,9 @@ pub struct Stats {
 }
 
 impl Stats {
-    pub fn new(flamegraph_precision: f64) -> Stats {
+    pub fn new(flame_min_width: f64) -> Stats {
         Stats {
-            min_width: flamegraph_precision,
+            min_width: flame_min_width,
             ..Default::default()
         }
     }

--- a/src/ui/flamegraph.rs
+++ b/src/ui/flamegraph.rs
@@ -14,9 +14,9 @@ pub struct Stats {
 }
 
 impl Stats {
-    pub fn new(flamegraph_precision: u32) -> Stats {
+    pub fn new(flamegraph_precision: f64) -> Stats {
         Stats {
-            min_width: 1_f64/(flamegraph_precision as f64),
+            min_width: flamegraph_precision,
             ..Default::default()
         }
     }
@@ -62,7 +62,7 @@ mod tests {
 
     #[test]
     fn test_stats() -> Result<(), io::Error> {
-        let mut stats = Stats::new(10);
+        let mut stats = Stats::new(0.1);
 
         stats.record(&vec![f(1)])?;
         stats.record(&vec![f(2), f(1)])?;


### PR DESCRIPTION
Following suggestion #275, here is my first rust PR :tada: 

Ok so the idea is to be able to control the `min_width` [option from inferno](https://docs.rs/inferno/0.10.1/inferno/flamegraph/struct.Options.html#structfield.min_width) which is currently kept to the default of `0.1%`. It could be useful for people like me who run long profiling (and so have many sample so good precision) to be able to decrease this number to have more details in smaller flames.

So in this PR I tried to add a `flamegraph-precision` option, which is an integer (I couldn't manage to put a float in the `Record` struct), defined as:

```
> rbspy record --help
...
OPTIONS:
...
        --flamegraph-precision <PRECISION>    Minimum flame width = 1/PRECISION % [default: 10]
```

So default value of 10 = 0.1%, setting 1 would give 1% (lower precision) and setting 100 would give 0.01% (higher precision) for example.

I tested this locally and was able to successfully generate more or less detailed flamegraphs. I added an automated test for the parameter parsing which passes:

```
> cargo test test_arg_parsing

... skipping all warning ...

    Finished test [unoptimized + debuginfo] target(s) in 0.05s
     Running target/debug/deps/rbspy-57c9c1ccd82df402

running 1 test
test tests::test_arg_parsing ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 18 filtered out
```

The other tests are not all running on my machine (Ubuntu 20.04) and one hangs the suite (with master) but that is an unrelated matter. The test suite is green on Travis :+1: 

I am not sure if I passed the argument the right way, let me know if you think I should rewrite this another way.
I let the default value of 0.1% for the `report` command, let me know if I should also add the parameter to this command too!

Thanks :bow: and sorry in advance if I wrote any rust monstrosity :see_no_evil: 