### PR TITLE
Adds support for linux arm builds

### DIFF
--- a/src/core/ruby_version.rs
+++ b/src/core/ruby_version.rs
@@ -319,7 +319,7 @@ macro_rules! get_ruby_string(
                 let basic = rstring.basic;
                 let is_array = basic.flags & 1 << 13 == 0;
                 if is_array {
-                    unsafe { CStr::from_ptr(rstring.as_.ary.as_ref().as_ptr() as *const i8) }
+                    unsafe { CStr::from_ptr(rstring.as_.ary.as_ref().as_ptr() as *const libc::c_char) }
                     .to_bytes()
                         .to_vec()
                 } else {


### PR DESCRIPTION
### Summary of the issue

it looks like on linux arm `libc::char` is `u8`, not `i8`, so I just replace `i8` with `libc::char` to make this code more portable.

### Tests I did

To test it I used the following Dockerfile:

```Dockerfile
FROM alpine:3.12 as rust-builder

RUN apk update &&\
    apk add git gcc g++ make build-base openssl-dev musl musl-dev \
    rust cargo curl

RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
RUN /root/.cargo/bin/rustup target add $(uname -m)-unknown-linux-musl

RUN wget https://github.com/libunwind/libunwind/releases/download/v1.3.1/libunwind-1.3.1.tar.gz
RUN tar -zxvf libunwind-1.3.1.tar.gz
RUN cd libunwind-1.3.1/ && ./configure --disable-minidebuginfo --enable-ptrace --disable-tests --disable-documentation && make && make install

COPY . /opt/rbspy

WORKDIR /opt/rbspy

ENV RUSTFLAGS="-C target-feature=+crt-static"
RUN /root/.cargo/bin/cargo build --release --target $(uname -m)-unknown-linux-musl


FROM ruby:2.7.2-alpine3.12

COPY --from=rust-builder /opt/rbspy /opt/rbspy

RUN echo "puts Process.pid; start_time = Time.new; i = 0; while Time.new < start_time + 30; i+=1; end; puts i" > /example.rb
CMD ["/opt/rbspy/target/aarch64-unknown-linux-musl/release/rbspy", "record", "ruby", "/example.rb"]

```

and I ran this on an M1 macbook:
```shell
docker build -t rbspy-test .
docker run --cap-add SYS_PTRACE -it rbspy-test
```
