### PR TITLE
Add GitHub action to publish to crates.io on release

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,21 @@
+name: Release to crates.io
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  rust-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Publishing crates
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_TOKEN }}


### PR DESCRIPTION
This aims to fix #277 

I don't know how to test this, so I'm just going to merge it, create a release, and see if it publishes a crate. I copied this from https://github.com/rillrate/rillrate-js/blob/ab5b83d1ea50d1673cbcbb8f5cf75ece7966f24c/.github/workflows/release-crates.yaml. 