### PR TITLE
Fix flaky subprocess test

### DIFF
--- a/ci/ruby-programs/ruby_forks.rb
+++ b/ci/ruby-programs/ruby_forks.rb
@@ -1,4 +1,4 @@
-SLEEP_TIME = 2
+SLEEP_TIME = 5
 
 suprocess_cmd = <<-CMD
   pid1_1 = spawn(ENV, RbConfig.ruby, "-esleep(#{SLEEP_TIME})")

--- a/src/core/initialize.rs
+++ b/src/core/initialize.rs
@@ -2,7 +2,7 @@ use crate::core::address_finder::*;
 use crate::core::address_finder;
 use proc_maps::MapRange;
 use crate::core::ruby_version;
-use crate::core::types::{MemoryCopyError, Pid, Process,
+use crate::core::types::{MemoryCopyError, Pid, Process, ProcessRetry,
                          ProcessMemory, StackTrace};
 
 use failure::Error;
@@ -26,7 +26,7 @@ use std;
  *   * Package all that up into a struct that the user can use to get stack traces.
  */
 pub fn initialize(pid: Pid) -> Result<StackTraceGetter, Error> {
-    let process = Process::new(pid)?;
+    let process = Process::new_with_retry(pid)?;
     let (current_thread_addr_location, global_symbols_addr_location, stack_trace_function) = get_process_ruby_state(&process)?;
 
     Ok(StackTraceGetter {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -116,3 +116,28 @@ impl From<Context<usize>> for MemoryCopyError {
         }
     }
 }
+pub trait ProcessRetry {
+    fn new_with_retry(pid: Pid) -> Result<Process, Error>;
+}
+
+impl ProcessRetry for remoteprocess::Process {
+    // It can take a moment for the ruby process to spin up, so new_with_retry automatically
+    // retries for a few seconds. This delay mostly seems to affect macOS and Windows and is
+    // especially common in CI environments.
+    fn new_with_retry(pid: Pid) -> Result<Process, Error> {
+        let retry_interval = std::time::Duration::from_millis(10);
+        let mut retries = 500;
+        loop {
+            match Process::new(pid) {
+                Ok(p) => return Ok(p),
+                Err(e) => {
+                    if retries == 0 {
+                        return Err(Error::from(e));
+                    }
+                    std::thread::sleep(retry_interval);
+                    retries -= 1;
+                }
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -495,7 +495,7 @@ fn test_spawn_record_children_subprocesses() {
         retries -= 1;
     }
 
-    let (trace_receiver, result_receiver, _, _) = spawn_recorder_children(pid, true, 20, None).unwrap();
+    let (trace_receiver, result_receiver, _, _) = spawn_recorder_children(pid, true, 10, None).unwrap();
 
     let results: Vec<_> = result_receiver.iter().take(4).collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ pub mod ui;
 pub(crate) mod storage;
 
 use crate::core::initialize::initialize;
-use crate::core::types::{MemoryCopyError, Pid, Process, StackTrace};
+use crate::core::types::{MemoryCopyError, Pid, Process, ProcessRetry, StackTrace};
 use ui::output;
 
 const BILLION: u64 = 1000 * 1000 * 1000; // for nanosleep
@@ -390,7 +390,7 @@ fn spawn_recorder_children(pid: Pid, with_subprocesses: bool, sample_rate: u32, 
         // appear
         let done_clone = done.clone();
         std::thread::spawn(move || {
-            let process = Process::new(pid).unwrap();
+            let process = Process::new_with_retry(pid).unwrap();
             let mut pids: HashSet<Pid> = HashSet::new();
             let done = done.clone();
             // we need to exit this loop when the process we're monitoring exits, otherwise the
@@ -482,18 +482,6 @@ fn test_spawn_record_children_subprocesses() {
         .unwrap();
 
     let pid = process.id() as Pid;
-
-    // It can take a moment for the ruby process to spin up, so retry a few times. This
-    // mostly seems to affect macOS and Windows.
-    let retry_interval = std::time::Duration::from_millis(10);
-    let mut retries = 1000;
-    while let Err(_) = Process::new(pid) {
-        if retries == 0 {
-            panic!("Couldn't get process handle for ruby PID {}", pid);
-        }
-        std::thread::sleep(retry_interval);
-        retries -= 1;
-    }
 
     let (trace_receiver, result_receiver, _, _) = spawn_recorder_children(pid, true, 10, None).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,7 +483,7 @@ fn test_spawn_record_children_subprocesses() {
 
     let pid = process.id() as Pid;
 
-    let (trace_receiver, result_receiver, _, _) = spawn_recorder_children(pid, true, 10, None).unwrap();
+    let (trace_receiver, result_receiver, _, _) = spawn_recorder_children(pid, true, 5, None).unwrap();
 
     let results: Vec<_> = result_receiver.iter().take(4).collect();
 


### PR DESCRIPTION
(... hopefully.)

The `test_spawn_record_children_subprocesses` has been failing consistently for me locally (macOS 11.2.1, 2019 MBP). I noticed that the test process was returning an error immediately -- before ruby_forks.rb had exited, and maybe before it had even started -- which made me wonder whether there was a startup delay that we weren't accounting for. Indeed, it seems to take a few hundred milliseconds before we can get a handle on the process. If we wait for that handle before spawning the recorders, it works consistently for me.

After fixing that, I noticed an intermittent related issue where the trace sender channel was filling up. I think that's the reason for the timeouts we've seen in CI recently -- the sender channel fills up, which blocks some recorders from exiting, which in turn blocks the subprocess test from collecting the results.

There is similar retry logic elsewhere (e.g. get_ruby_version_retry) that may explain why we don't see this behavior outside of the tests.

cc @igorwwwwwwwwwwwwwwwwwwww -- thanks for your earlier work on this 👍