### PR TITLE
Synchronous subprocess test

### DIFF
--- a/ci/ruby-programs/ruby_forks.rb
+++ b/ci/ruby-programs/ruby_forks.rb
@@ -1,17 +1,23 @@
-SLEEP_TIME = 5
+coordination_path = ARGV[0].gsub('\\', '/')
 
-suprocess_cmd = <<-CMD
-  pid1_1 = spawn(ENV, RbConfig.ruby, "-esleep(#{SLEEP_TIME})")
+# rbspy's test will indicate that it's gotten a stack trace from this PID by
+# creating a file on disk. Sleep until we see our file.
+wait_for_ack_func = %Q(
+  while !File.exists?(File.join("#{coordination_path}", "rbspy_ack." + Process.pid.to_s))
+    sleep(0.25)
+  end
+)
 
-  sleep #{SLEEP_TIME}
+subprocess_cmd = <<-CMD
+  pid1_1 = spawn(ENV, RbConfig.ruby, '-e #{wait_for_ack_func}')
+  eval '#{wait_for_ack_func}'
   Process.wait(pid1_1)
 CMD
 
-pid1 = spawn(ENV, RbConfig.ruby, "-e#{suprocess_cmd}")
+pid1 = spawn(ENV, RbConfig.ruby, "-e #{subprocess_cmd}")
+pid2 = spawn(ENV, RbConfig.ruby, "-e #{wait_for_ack_func}")
 
-pid2 = spawn(ENV, RbConfig.ruby, "-esleep(#{SLEEP_TIME})")
-
-sleep SLEEP_TIME
+eval wait_for_ack_func
 
 Process.wait(pid1)
 Process.wait(pid2)

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -34,6 +34,7 @@ pub struct StackTrace {
 
 #[derive(Fail, Debug)]
 pub enum MemoryCopyError {
+    #[fail(display = "The operation completed successfully")] OperationSucceeded,
     #[fail(display = "Permission denied when reading from process. If you're not running as root, try again with sudo. If you're using Docker, try passing `--cap-add=SYS_PTRACE` to `docker run`")]
 
     PermissionDenied,
@@ -105,6 +106,8 @@ impl From<Context<usize>> for MemoryCopyError {
         }
 
         return match error.raw_os_error() {
+            // Sometimes Windows returns this error code
+            Some(0) => MemoryCopyError::OperationSucceeded,
             /* On Mac, 60 seems to correspond to the process ended */
             /* On Windows, 299 happens when the process ended */
             Some(3) | Some(60) | Some(299) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -490,7 +490,7 @@ fn test_spawn_record_children_subprocesses() {
     // check that there are 4 distinct PIDs in the stack traces
     let pids: HashSet<Pid> = trace_receiver.iter().take(100).map(|x| x.pid.unwrap()).collect();
     for r in results {
-        assert!(r.is_ok());
+        r.expect("unexpected error");
     }
 
     assert_eq!(pids.len(), 4);

--- a/src/main.rs
+++ b/src/main.rs
@@ -491,7 +491,7 @@ fn test_spawn_record_children_subprocesses() {
         spawn_recorder_children(pid, true, 5, None).unwrap();
 
     let mut pids = HashSet::<Pid>::new();
-    for trace in trace_receiver {
+    for trace in &trace_receiver {
         let pid = trace.pid.unwrap();
         if !pids.contains(&pid) {
             // Now that we have a stack trace for this PID, signal to the corresponding
@@ -523,6 +523,8 @@ fn test_spawn_record_children_subprocesses() {
         #[cfg(not(target_os = "windows"))]
         r.expect("unexpected error");
     }
+
+    drop(trace_receiver);
 
     assert_eq!(pids.len(), 4);
     process.wait().unwrap();


### PR DESCRIPTION
We've still been seeing subprocess test failures in CI, especially on Windows. This PR refactors the subprocess test to coordinate with ruby_forks.rb using the filesystem instead of depending on the ruby processes' startup speed. The last commit is an ugly workaround for process exit behavior that hopefully can be fixed (maybe by #295).