### PR TITLE
Gracefully handle invalid pointers to absolute path strings

### DIFF
--- a/src/core/ruby_version.rs
+++ b/src/core/ruby_version.rs
@@ -435,9 +435,15 @@ macro_rules! get_ruby_string_array_2_5_0(
             // the reason I am not checking is that I don't know how to check yet
             let path_addr: usize = unsafe { rarray.as_.ary[0] as usize }; // 1 means get the absolute path, not the relative path
             let abs_path_addr: usize = unsafe { rarray.as_.ary[1] as usize }; // 1 means get the absolute path, not the relative path
-            Ok((get_ruby_string(path_addr, source)?, get_ruby_string(abs_path_addr, source)?))
+            let rel_path = get_ruby_string(path_addr, source)?;
+            // In the case of internal ruby functions (and maybe others), we may not get a valid
+            // pointer here
+            let abs_path = get_ruby_string(abs_path_addr, source)
+                .unwrap_or(String::from("unknown"));
+            Ok((rel_path, abs_path))
         }
-        ));
+    )
+);
 
 macro_rules! get_ruby_string(
     () => (


### PR DESCRIPTION
This is a workaround for the "early exit" bug. I was able to consistently repro this bug by running rbspy against rspec while it was running the test suite for a decent-sized Rails app. The proximate cause here is that we're trying to dereference a pointer to a memory address like `8`, which isn't valid (might be a length), and remoteprocess returns an error (code 60) that we map to `ProcessEnded` when we try to copy the memory. Maybe that error code covers more scenarios than process exit.

In my testing, we only seem to go down the RArray code path for strings like `<internal:gc>`. I suspect that those are encoded differently than normal strings. We have an implementation of ruby's `string2cstring` GDB macro in the C symbol resolution code that might be useful here -- it has two code paths depending on how a string is encoded.

More to do here, but I'm hoping this will be a decent workaround for folks who want to run rbspy for longer periods of time.

Fixes #190, fixes #221, fixes #243. Possibly also fixes #158, fixes #160, fixes #263.