### PR TITLE
Add @acj as an author to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rbspy"
 version = "0.4.0"
-authors = ["Julia Evans <julia@jvns.ca>"]
+authors = [ "Adam Jensen <acjensen@gmail.com>", "Julia Evans <julia@jvns.ca>"]
 description = "Sampling CPU profiler for Ruby"
 keywords = ["ruby", "profiler", "MRI"]
 license = "MIT"


### PR DESCRIPTION
I asked @acj if he'd be willing to be rbspy's lead maintainer since he's already been doing the work of adding support for new Ruby versions, implementing new features, fixing bugs, and improving the CI for the last couple of months, and he agreed!

This change to Cargo.toml is just symbolic: I've already given him all the GitHub/Cargo permissions he needs.

I'm extremely excited to have someone who's actually using rbspy as the maintainer.