### PR TITLE
Move contributors list to CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,7 @@
+Everyone in the [rbspy contributors list](https://github.com/rbspy/rbspy/graphs/contributors),
+plus (in alphabetical order) some people who aren't in the commit log: 
+
+* [Ashley McNamara](https://github.com/ashleymcnamara) made the logo
+* [Julian Squires](https://github.com/tokenrove/) for some very helpful early conversations and suggesting `process_vm_readv`
+* [Kamal Marhubi](https://github.com/kamalmarhubi) came up with the [testing framework](https://github.com/rbspy/rbspy-testdata/commit/431814a7eb50b0bde083b2a52be9e5f68e117518) and code reviewed/pair programmed the initial implementation
+* [Scott Francis](https://github.com/csfrancis) wrote very helpful blog posts on Ruby profiling with gdb (rbspy is very heavily inspired by [this gist](https://gist.github.com/csfrancis/11376304))

--- a/README.md
+++ b/README.md
@@ -79,9 +79,3 @@ Here are the steps for maintainers to tag a new release:
 1. Open a PR for the version bump. You can generate a CHANGELOG via `git log --pretty='- %s' v0.3.10...HEAD`.
 1. After the PR is merged, tag the new release, e.g. `git tag v0.3.11`, and push it: `git push --tags`.
 1. Travis will publish the tarballs to GitHub.
-
-## Contributors
-
-* [Julia Evans](https://github.com/jvns)
-* [Kamal Marhubi](https://github.com/kamalmarhubi)
-* [Joel Johnson](https://github.com/liaden/)


### PR DESCRIPTION
The contributors list was incredibly out of date, so this replaces it with a new CONTRIBUTORS.md file with the goal of recognizing contributors who helped make rbspy possible but aren't in the commit log.