### PR TITLE
Fix subprocess exit bug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -501,7 +501,6 @@ fn spawn_recorder_children(
 }
 
 // TODO: Find a more reliable way to test this on Windows hosts
-#[cfg(not(target_os = "windows"))]
 #[test]
 fn test_spawn_record_children_subprocesses() {
     let which = if cfg!(target_os = "windows") {
@@ -554,16 +553,6 @@ fn test_spawn_record_children_subprocesses() {
 
     let results: Vec<_> = result_receiver.iter().take(4).collect();
     for r in results {
-        #[cfg(target_os = "windows")]
-        match &r {
-            Ok(_) => {}
-            Err(e) => match e.downcast_ref() {
-                Some(MemoryCopyError::OperationSucceeded) => {}
-                _ => r.expect("unexpected error"),
-            },
-        }
-
-        #[cfg(not(target_os = "windows"))]
         r.expect("unexpected error");
     }
 


### PR DESCRIPTION
rbspy currently stops profiling when any one of the processes it's tracking exits. This creates a subtle race condition for the subprocess test, which has been very flaky on macOS and Windows, and also seems like undesirable behavior since subprocesses are expected to come and go in many applications. There may also be use cases where the root process is expected to exit before its subprocesses, but I think this change will cover the 99% case pretty well.

I realized this while experimenting with `--test-threads` for an unrelated issue. When I limited the threads to one or two (which is close to CI worker specs), the subprocess test consistently failed.

@jvns, when you have a moment could you please take a peek at this? I'm curious if there's a historical reason why we were exiting as soon as the first process ended.

Fixes #287