### PR TITLE
Pause target process when retrieving stack frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
  "libc",
  "libproc",
  "log",
- "nix 0.20.0",
+ "nix 0.19.1",
  "proc-maps",
  "rand 0.8.3",
  "rbspy-ruby-structs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tempdir = "0.3"
 thiserror = "1.0.24"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.20.0"
+nix = "0.19.1"
 
 [target.'cfg(target_os="macos")'.dependencies]
 libproc = "0.9.1"

--- a/src/core/initialize.rs
+++ b/src/core/initialize.rs
@@ -86,6 +86,10 @@ impl StackTraceGetter {
                                 std::io::ErrorKind::NotFound => {
                                     return Err(MemoryCopyError::ProcessEnded)
                                 }
+                                // Windows
+                                std::io::ErrorKind::PermissionDenied => {
+                                    return Err(MemoryCopyError::ProcessEnded)
+                                }
                                 _ => {}
                             };
                         }


### PR DESCRIPTION
We don't currently pause the target process when calling `get_stack_frame`, which results in incorrect and misleading profiler output like we see in #315. The `remoteprocess` crate has support for pausing processes on each platform. The output seems much more accurate in my testing, so I'm going to enable it.

Using higher sampling frequencies will degrade performance of the target process while rbspy is running, but 1) this is already true, at least on some systems, because of higher CPU usage, and 2) it feels like a reasonable tradeoff for the sake of correctness. If we find that it's a problem, we could consider adding a flag to disable pausing.

Fixes #153. Fixes #315.