### PR TITLE
333: initialize tests; make sure processes are killed

### DIFF
--- a/src/core/initialize.rs
+++ b/src/core/initialize.rs
@@ -1,6 +1,4 @@
 use crate::core::address_finder;
-#[cfg(target_os = "linux")]
-use crate::core::address_finder::*;
 use crate::core::ruby_version;
 use crate::core::types::{MemoryCopyError, Pid, Process, ProcessMemory, ProcessRetry, StackTrace};
 use proc_maps::MapRange;
@@ -67,7 +65,7 @@ impl StackTraceGetter {
                 };
             }
             Err(MemoryCopyError::InvalidAddressError(addr))
-                if addr == self.current_thread_addr_location => {}
+            if addr == self.current_thread_addr_location => {}
             Err(e) => return Err(e.into()),
         }
         debug!("Thread address location invalid, reinitializing");
@@ -92,11 +90,11 @@ impl StackTraceGetter {
                             Ok(remoteprocess::Error::IOError(e)) => {
                                 match e.kind() {
                                     std::io::ErrorKind::NotFound => {
-                                        return Err(MemoryCopyError::ProcessEnded)
+                                        return Err(MemoryCopyError::ProcessEnded);
                                     }
                                     // Windows
                                     std::io::ErrorKind::PermissionDenied => {
-                                        return Err(MemoryCopyError::ProcessEnded)
+                                        return Err(MemoryCopyError::ProcessEnded);
                                     }
                                     _ => {}
                                 };
@@ -150,7 +148,7 @@ pub type IsMaybeThreadFn = Box<dyn Fn(usize, usize, &Process, &[MapRange]) -> bo
 // Everything below here is private
 
 type StackTraceFn =
-    Box<dyn Fn(usize, usize, Option<usize>, &Process, Pid) -> Result<StackTrace, MemoryCopyError>>;
+Box<dyn Fn(usize, usize, Option<usize>, &Process, Pid) -> Result<StackTrace, MemoryCopyError>>;
 
 fn get_process_ruby_state(
     pid: Pid,
@@ -186,10 +184,10 @@ fn get_process_ruby_state(
             if i > 100 {
                 match e.root_cause().downcast_ref::<std::io::Error>() {
                     Some(root_cause)
-                        if root_cause.kind() == std::io::ErrorKind::PermissionDenied =>
-                    {
-                        return Err(e.context("Failed to initialize due to a permissions error. If you are running rbspy as a normal (non-root) user, please try running it again with `sudo --preserve-env !!`. If you are running it in a container, e.g. with Docker or Kubernetes, make sure that your container has been granted the SYS_PTRACE capability. See the rbspy documentation for more details."));
-                    }
+                    if root_cause.kind() == std::io::ErrorKind::PermissionDenied =>
+                        {
+                            return Err(e.context("Failed to initialize due to a permissions error. If you are running rbspy as a normal (non-root) user, please try running it again with `sudo --preserve-env !!`. If you are running it in a container, e.g. with Docker or Kubernetes, make sure that your container has been granted the SYS_PTRACE capability. See the rbspy documentation for more details."));
+                        }
                     _ => {}
                 }
                 return Err(anyhow::format_err!("Couldn't get ruby version: {:?}", e));
@@ -248,159 +246,6 @@ fn get_ruby_version(process: &Process) -> Result<String> {
             .to_str()?
             .to_owned()
     })
-}
-
-#[test]
-#[cfg(target_os = "linux")]
-fn test_initialize_with_nonexistent_process() {
-    let process = Process::new(10000).expect("Failed to initialize process");
-    let version = get_ruby_version(&process);
-    match version
-        .unwrap_err()
-        .root_cause()
-        .downcast_ref::<AddressFinderError>()
-        .unwrap()
-    {
-        &AddressFinderError::NoSuchProcess(10000) => {}
-        _ => assert!(false, "Expected NoSuchProcess error"),
-    }
-}
-
-#[test]
-#[cfg(target_os = "linux")]
-fn test_initialize_with_disallowed_process() {
-    let process = Process::new(1).expect("Failed to initialize process");
-    let version = get_ruby_version(&process);
-    match version
-        .unwrap_err()
-        .root_cause()
-        .downcast_ref::<AddressFinderError>()
-        .unwrap()
-    {
-        &AddressFinderError::PermissionDenied(1) => {}
-        _ => assert!(false, "Expected PermissionDenied error"),
-    }
-}
-
-#[test]
-#[cfg(target_os = "linux")]
-fn test_current_thread_address() {
-    let mut process = std::process::Command::new("ruby")
-        .arg("./ci/ruby-programs/infinite.rb")
-        .spawn()
-        .unwrap();
-    let pid = process.id() as Pid;
-    let remoteprocess = Process::new(pid).expect("Failed to initialize process");
-    let version;
-    let mut i = 0;
-    loop {
-        // It can take a moment for the process to become ready, so retry as needed
-        let r = get_ruby_version(&remoteprocess);
-        if r.is_ok() {
-            version = r.unwrap();
-            break;
-        }
-        if i > 100 {
-            panic!("couldn't get ruby version");
-        }
-        i += 1;
-        std::thread::sleep(Duration::from_millis(1));
-    }
-    if version >= String::from("3.0.0") {
-        // We won't be able to get the thread address directly, so skip this
-        return;
-    }
-
-    let is_maybe_thread = is_maybe_thread_function(&version);
-    let result = address_finder::current_thread_address(pid, &version, is_maybe_thread);
-    result.expect("unexpected error");
-    process.kill().unwrap();
-}
-
-#[test]
-#[cfg(target_os = "linux")]
-fn test_get_trace() {
-    // Test getting a stack trace from a real running program using system Ruby
-    let mut process = std::process::Command::new("ruby")
-        .arg("./ci/ruby-programs/infinite.rb")
-        .spawn()
-        .unwrap();
-    let pid = process.id() as Pid;
-    let mut getter = initialize(pid, true).unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(50));
-    let trace = getter.get_trace();
-    assert!(trace.is_ok());
-    assert_eq!(trace.unwrap().pid, Some(pid));
-    process.kill().unwrap();
-}
-
-#[test]
-#[cfg(target_os = "linux")]
-fn test_get_exec_trace() {
-    use std::io::Write;
-
-    // Test collecting stack samples across an exec call
-    let mut process = std::process::Command::new("ruby")
-        .arg("./ci/ruby-programs/ruby_exec.rb")
-        .arg("ruby")
-        .stdin(std::process::Stdio::piped())
-        .spawn()
-        .unwrap();
-
-    let pid = process.id() as Pid;
-    let mut getter = initialize(pid, true).expect("initialize");
-
-    std::thread::sleep(std::time::Duration::from_millis(50));
-    let trace1 = getter.get_trace();
-
-    assert!(
-        trace1.is_ok(),
-        "initial trace failed: {:?}",
-        trace1.unwrap_err()
-    );
-    assert_eq!(trace1.unwrap().pid, Some(pid));
-
-    // Trigger the exec
-    writeln!(process.stdin.as_mut().unwrap()).expect("write to exec");
-
-    let allowed_attempts = 20;
-    for _ in 0..allowed_attempts {
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        let trace2 = getter.get_trace();
-
-        if getter.reinit_count == 0 {
-            continue;
-        }
-
-        assert!(
-            trace2.is_ok(),
-            "post-exec trace failed: {:?}",
-            trace2.unwrap_err()
-        );
-    }
-
-    process.kill().unwrap();
-
-    assert_eq!(
-        getter.reinit_count, 1,
-        "Trace getter should have detected one reinit"
-    );
-}
-
-#[test]
-#[cfg(target_os = "macos")]
-fn test_get_nonexistent_process() {
-    assert!(Process::new(10000).is_err());
-}
-
-#[test]
-#[cfg(target_os = "macos")]
-fn test_get_disallowed_process() {
-    // getting the ruby version isn't allowed on Mac if the process isn't running as root
-    let mut process = std::process::Command::new("/usr/bin/ruby").spawn().unwrap();
-    let pid = process.id() as Pid;
-    assert!(Process::new(pid).is_err());
-    process.kill().unwrap();
 }
 
 fn is_maybe_thread_function(version: &str) -> IsMaybeThreadFn {
@@ -567,4 +412,186 @@ fn get_stack_trace_function(version: &str) -> StackTraceFn {
         ),
     };
     Box::new(stack_trace_function)
+}
+
+#[cfg(test)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+mod test {
+    #[cfg(target_os = "linux")]
+    use crate::core::address_finder::AddressFinderError;
+    use crate::core::types::{Pid, Process};
+    use crate::core::initialize::{is_maybe_thread_function, get_ruby_version};
+    use crate::core::address_finder;
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_initialize_with_nonexistent_process() {
+        let process = Process::new(10000).expect("Failed to initialize process");
+        let version = get_ruby_version(&process);
+        match version
+            .unwrap_err()
+            .root_cause()
+            .downcast_ref::<AddressFinderError>()
+            .unwrap()
+        {
+            &AddressFinderError::NoSuchProcess(10000) => {}
+            _ => assert!(false, "Expected NoSuchProcess error"),
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_initialize_with_disallowed_process() {
+        let process = Process::new(1).expect("Failed to initialize process");
+        let version = get_ruby_version(&process);
+        match version
+            .unwrap_err()
+            .root_cause()
+            .downcast_ref::<AddressFinderError>()
+            .unwrap()
+        {
+            &AddressFinderError::PermissionDenied(1) => {}
+            _ => assert!(false, "Expected PermissionDenied error"),
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_current_thread_address() {
+        if let Ok(mut process) = std::process::Command::new("ruby")
+            .arg("./ci/ruby-programs/infinite.rb")
+            .spawn() {
+            let pid = process.id() as Pid;
+            let remoteprocess = Process::new(pid).expect("Failed to initialize process");
+            let version;
+            let mut i = 0;
+            loop {
+                // It can take a moment for the process to become ready, so retry as needed
+                let r = get_ruby_version(&remoteprocess);
+                if r.is_ok() {
+                    version = r.unwrap();
+                    break;
+                }
+                if i > 100 {
+                    process.kill().unwrap();
+                    assert!(false, "couldn't get ruby version");
+                    return;
+                }
+                i += 1;
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            if version >= String::from("3.0.0") {
+                // We won't be able to get the thread address directly, so skip this
+                process.kill().unwrap();
+                return;
+            }
+
+            let is_maybe_thread = is_maybe_thread_function(&version);
+            let result = address_finder::current_thread_address(pid, &version, is_maybe_thread);
+            result.expect("unexpected error");
+            process.kill().unwrap();
+        } else {
+            assert!(false, "Can't start ruby infinite.rb");
+        }
+    }
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_get_trace() {
+    // Test getting a stack trace from a real running program using system Ruby
+    if let Ok(mut process) = std::process::Command::new("ruby")
+        .arg("./ci/ruby-programs/infinite.rb")
+        .spawn()
+    {
+        let pid = process.id() as Pid;
+        match initialize(pid, true) {
+            Ok(mut getter) => {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                let trace = getter.get_trace();
+                assert!(trace.is_ok());
+                assert_eq!(trace.unwrap().pid, Some(pid));
+                process.kill().unwrap();
+            }
+            Err(_) => process.kill().unwrap()
+        }
+    } else {
+        assert!(false, "Can't start ruby infinite.rb");
+    }
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_get_exec_trace() {
+    use std::io::Write;
+
+    // Test collecting stack samples across an exec call
+    if let Ok(mut process) = std::process::Command::new("ruby")
+        .arg("./ci/ruby-programs/ruby_exec.rb")
+        .arg("ruby")
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+    {
+        let pid = process.id() as Pid;
+        match initialize(pid, true) {
+            Ok(mut getter) => {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                let trace1 = getter.get_trace();
+
+                assert!(
+                    trace1.is_ok(),
+                    "initial trace failed: {:?}",
+                    trace1.unwrap_err()
+                );
+                assert_eq!(trace1.unwrap().pid, Some(pid));
+
+                // Trigger the exec
+                writeln!(process.stdin.as_mut().unwrap()).expect("write to exec");
+
+                let allowed_attempts = 20;
+                for _ in 0..allowed_attempts {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    let trace2 = getter.get_trace();
+
+                    if getter.reinit_count == 0 {
+                        continue;
+                    }
+
+                    assert!(
+                        trace2.is_ok(),
+                        "post-exec trace failed: {:?}",
+                        trace2.unwrap_err()
+                    );
+                }
+
+                process.kill().unwrap();
+                assert_eq!(
+                    getter.reinit_count, 1,
+                    "Trace getter should have detected one reinit"
+                );
+            }
+            Err(e) => {
+                process.kill().unwrap();
+                assert!(false, "{}", e.to_string());
+            }
+        }
+    } else {
+        assert!(false, "Can't start ruby infinite.rb");
+    }
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn test_get_nonexistent_process() {
+    assert!(Process::new(10000).is_err());
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn test_get_disallowed_process() {
+    // getting the ruby version isn't allowed on Mac if the process isn't running as root
+    let mut process = std::process::Command::new("/usr/bin/ruby").spawn().unwrap();
+    let pid = process.id() as Pid;
+    assert!(Process::new(pid).is_err());
+    process.kill().unwrap();
 }


### PR DESCRIPTION
@acj regardless #333 , a small rewrite of `initialize` tests, `test_spawn_record_children_subprocesses` issues is not fixed in this commit