### PR TITLE
Allow retrying process locking in case of spurious issues

### DIFF
--- a/ci/ruby-programs/thread_churn.rb
+++ b/ci/ruby-programs/thread_churn.rb
@@ -1,0 +1,15 @@
+while true
+    t1 = Thread.new {
+        (0..rand(100)).map { Thread.new { sleep(0.01) } }.each(&:join)
+    }
+    t2 = Thread.new {
+        (0..rand(100)).map { Thread.new { sleep(0.02) } }.each(&:join)
+    }
+    t3 = Thread.new {
+        (0..rand(100)).map { Thread.new { sleep(0.03) } }.each(&:join)
+    }
+
+    t1.join()
+    t2.join()
+    t3.join()
+end

--- a/src/core/initialize.rs
+++ b/src/core/initialize.rs
@@ -130,7 +130,7 @@ impl StackTraceGetter {
 
         let _lock;
         if self.lock_process {
-            let mut retries = 10;
+            let mut retries = 20;
             loop {
                 match try_lock(&self.process) {
                     Ok(l) => {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -42,6 +42,8 @@ pub enum MemoryCopyError {
     Io(usize, std::io::Error),
     #[error("Process isn't running")]
     ProcessEnded,
+    #[error("Couldn't lock the process")]
+    ProcessNotLocked,
     #[error("Copy error: {}", _0)]
     Message(String),
     #[error("Too much memory requested when copying: {}", _0)]

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -42,6 +42,8 @@ pub enum MemoryCopyError {
     Io(usize, std::io::Error),
     #[error("Process isn't running")]
     ProcessEnded,
+    #[error("Permission error")]
+    PermissionError,
     #[error("Couldn't lock the process")]
     ProcessNotLocked,
     #[error("Copy error: {}", _0)]


### PR DESCRIPTION
Attempt to fix https://github.com/rbspy/rbspy/issues/334

# Problem being solved

It appears that in some cases attempting to lock the process will fail, when running rbspy without `--nonblocking`. This is fairly easy to reproduce by setting the sample rate to something very high (500 or 1000), as this increases the likelyhood that it will fail to lock one of the threads associated with the process.

It looks like the [implementation of `lock`](https://docs.rs/remoteprocess/0.4.3/src/remoteprocess/linux/mod.rs.html#65-86) is inherently racy on linux because it interacts with the system when trying to lock a thread via the call to ptrace, it is possible that the **thread** will no longer exist, and ptrace will correctly return ESRCH in this case. However, we treat failing to lock the process due to this error as if the process itself does not exist, which leads to the whole tracer exiting, thinking the target process is no longer running when it in fact still is.

# Solution

To resolve this problem, as @acj has suggested in https://github.com/rbspy/rbspy/issues/334#issuecomment-885937078, I introduce some retry logic:

- The current locking code is moved to a closure, `try_lock`, so that it can be easily called repeatedly
- A new type of MemoryCopyError specific to this issue is introduce, `ProcessNotLocked`, which is returned by the closure if we detect that we got ESRCH, but the process still exists
- We will retry locking up to 10 times, but only if we received `ProcessNotLocked` each time - on any other type of error, the retry loop will be broken immediately. In practice one retry is probably sufficient, and it is highly unlikely that it should hit his error ten times in a row, but ten seems like a reasonable upper limit to the retries.
- Even if all retries were exhausted, the error is still distinguished from `ProcessEnded`, so the original bug of this tripping https://github.com/rbspy/rbspy/blob/master/src/main.rs#L702 should be fix; this error will be treated as any other error, and not claim a successful exit

Using the modifications here, I was able to profile a production puma process for 120 seconds uninterrupted, at 500hz, which I cannot do without this patch.

Note - i am very unfamiliar with Rust, this is just my first attempt at a solution as I am also trying to maneuver my way around the language. All feedback including nitpicks and style suggestions, and comments on standard idiom are sincerely welcome.

Since the check suite doesn't run for new contributors, here is the run on my own fork: https://github.com/dalehamel/rbspy/runs/3168336700?check_suite_focus=true