### PR TITLE
Add pprof output format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +280,12 @@ dependencies = [
  "cfg-if",
  "num_cpus",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elf"
@@ -483,6 +495,15 @@ dependencies = [
  "rgb",
  "str_stack",
  "structopt",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -759,6 +780,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +912,7 @@ dependencies = [
  "log",
  "nix",
  "proc-maps",
+ "prost",
  "rand 0.8.4",
  "rbspy-ruby-structs",
  "rbspy-testdata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ flate2 = "1.0.20"
 libc = "0.2.34"
 log = "0.4.6"
 proc-maps = "0.2.0"
+prost = "0.9"
 rand = "0.8.3"
 rbspy-ruby-structs = { path = "ruby-structs", version="0.8.0" }
 remoteprocess = "0.4.5"

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -134,6 +134,7 @@ arg_enum! {
         collapsed,
         callgrind,
         speedscope,
+        pprof,
         summary,
         summary_by_line,
     }
@@ -146,6 +147,7 @@ impl OutputFormat {
             OutputFormat::collapsed => Box::new(output::Collapsed::default()),
             OutputFormat::callgrind => Box::new(output::Callgrind(callgrind::Stats::new())),
             OutputFormat::speedscope => Box::new(output::Speedscope(speedscope::Stats::new())),
+            OutputFormat::pprof => Box::new(output::Pprof(pprof::Stats::new())),
             OutputFormat::summary => Box::new(output::Summary(summary::Stats::new())),
             OutputFormat::summary_by_line => Box::new(output::SummaryLine(summary::Stats::new())),
         }
@@ -157,6 +159,7 @@ impl OutputFormat {
             OutputFormat::collapsed => "collapsed.txt",
             OutputFormat::callgrind => "callgrind.txt",
             OutputFormat::speedscope => "speedscope.json",
+            OutputFormat::pprof => "profile.pb.gz",
             OutputFormat::summary => "summary.txt",
             OutputFormat::summary_by_line => "summary_by_line.txt",
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 pub mod callgrind;
 pub mod flamegraph;
 pub mod output;
+pub mod pprof;
 pub mod speedscope;
 pub mod summary;

--- a/src/ui/output.rs
+++ b/src/ui/output.rs
@@ -4,7 +4,7 @@ extern crate tempdir;
 use std::io::Write;
 
 use crate::core::types::{StackFrame, StackTrace};
-use crate::ui::{callgrind, flamegraph, speedscope, summary};
+use crate::ui::{callgrind, flamegraph, pprof, speedscope, summary};
 
 use anyhow::Result;
 
@@ -105,6 +105,20 @@ pub struct Speedscope(pub speedscope::Stats);
 impl Outputter for Speedscope {
     fn record(&mut self, stack: &StackTrace) -> Result<()> {
         self.0.record(&stack)?;
+        Ok(())
+    }
+
+    fn complete(&mut self, write: &mut dyn Write) -> Result<()> {
+        self.0.write(write)?;
+        Ok(())
+    }
+}
+
+pub struct Pprof(pub pprof::Stats);
+
+impl Outputter for Pprof {
+    fn record(&mut self, stack: &StackTrace) -> Result<()> {
+        self.0.record(stack)?;
         Ok(())
     }
 

--- a/src/ui/perftools.profiles.rs
+++ b/src/ui/perftools.profiles.rs
@@ -1,0 +1,241 @@
+/*
+ * This file contains data structures to support generation of rbspy profiles in 
+ * pprof-compatible format.
+ *
+ * The prost crate (https://crates.io/crates/prost) was used to generate this
+ * file from the protobuf spec found in the pprof project repo at
+ * https://github.com/google/pprof/blob/master/proto/profile.proto
+ * 
+ * EVERYTHING BELOW THIS LINE HAS BEEN AUTO-GENERATED */
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Profile {
+    /// A description of the samples associated with each Sample.value.
+    /// For a cpu profile this might be:
+    ///   \[["cpu","nanoseconds"]\] or \[["wall","seconds"]\] or \[["syscall","count"]\]
+    /// For a heap profile, this might be:
+    ///   \[["allocations","count"\], \["space","bytes"]\],
+    /// If one of the values represents the number of events represented
+    /// by the sample, by convention it should be at index 0 and use
+    /// sample_type.unit == "count".
+    #[prost(message, repeated, tag="1")]
+    pub sample_type: ::prost::alloc::vec::Vec<ValueType>,
+    /// The set of samples recorded in this profile.
+    #[prost(message, repeated, tag="2")]
+    pub sample: ::prost::alloc::vec::Vec<Sample>,
+    /// Mapping from address ranges to the image/binary/library mapped
+    /// into that address range.  mapping\[0\] will be the main binary.
+    #[prost(message, repeated, tag="3")]
+    pub mapping: ::prost::alloc::vec::Vec<Mapping>,
+    /// Useful program location
+    #[prost(message, repeated, tag="4")]
+    pub location: ::prost::alloc::vec::Vec<Location>,
+    /// Functions referenced by locations
+    #[prost(message, repeated, tag="5")]
+    pub function: ::prost::alloc::vec::Vec<Function>,
+    /// A common table for strings referenced by various messages.
+    /// string_table\[0\] must always be "".
+    #[prost(string, repeated, tag="6")]
+    pub string_table: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// frames with Function.function_name fully matching the following
+    /// regexp will be dropped from the samples, along with their successors.
+    ///
+    /// Index into string table.
+    #[prost(int64, tag="7")]
+    pub drop_frames: i64,
+    /// frames with Function.function_name fully matching the following
+    /// regexp will be kept, even if it matches drop_functions.
+    ///
+    /// Index into string table.
+    #[prost(int64, tag="8")]
+    pub keep_frames: i64,
+    // The following fields are informational, do not affect
+    // interpretation of results.
+
+    /// Time of collection (UTC) represented as nanoseconds past the epoch.
+    #[prost(int64, tag="9")]
+    pub time_nanos: i64,
+    /// Duration of the profile, if a duration makes sense.
+    #[prost(int64, tag="10")]
+    pub duration_nanos: i64,
+    /// The kind of events between sampled ocurrences.
+    /// e.g [ "cpu","cycles" ] or [ "heap","bytes" ]
+    #[prost(message, optional, tag="11")]
+    pub period_type: ::core::option::Option<ValueType>,
+    /// The number of events between sampled occurrences.
+    #[prost(int64, tag="12")]
+    pub period: i64,
+    /// Freeform text associated to the profile.
+    ///
+    /// Indices into string table.
+    #[prost(int64, repeated, tag="13")]
+    pub comment: ::prost::alloc::vec::Vec<i64>,
+    /// Index into the string table of the type of the preferred sample
+    /// value. If unset, clients should default to the last sample value.
+    #[prost(int64, tag="14")]
+    pub default_sample_type: i64,
+}
+/// ValueType describes the semantics and measurement units of a value.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValueType {
+    /// Index into string table.
+    #[prost(int64, tag="1")]
+    pub r#type: i64,
+    /// Index into string table.
+    #[prost(int64, tag="2")]
+    pub unit: i64,
+}
+/// Each Sample records values encountered in some program
+/// context. The program context is typically a stack trace, perhaps
+/// augmented with auxiliary information like the thread-id, some
+/// indicator of a higher level request being handled etc.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Sample {
+    /// The ids recorded here correspond to a Profile.location.id.
+    /// The leaf is at location_id\[0\].
+    #[prost(uint64, repeated, tag="1")]
+    pub location_id: ::prost::alloc::vec::Vec<u64>,
+    /// The type and unit of each value is defined by the corresponding
+    /// entry in Profile.sample_type. All samples must have the same
+    /// number of values, the same as the length of Profile.sample_type.
+    /// When aggregating multiple samples into a single sample, the
+    /// result has a list of values that is the element-wise sum of the
+    /// lists of the originals.
+    #[prost(int64, repeated, tag="2")]
+    pub value: ::prost::alloc::vec::Vec<i64>,
+    /// label includes additional context for this sample. It can include
+    /// things like a thread id, allocation size, etc
+    #[prost(message, repeated, tag="3")]
+    pub label: ::prost::alloc::vec::Vec<Label>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Label {
+    /// Index into string table
+    #[prost(int64, tag="1")]
+    pub key: i64,
+    /// At most one of the following must be present
+    ///
+    /// Index into string table
+    #[prost(int64, tag="2")]
+    pub str: i64,
+    #[prost(int64, tag="3")]
+    pub num: i64,
+    /// Should only be present when num is present.
+    /// Specifies the units of num.
+    /// Use arbitrary string (for example, "requests") as a custom count unit.
+    /// If no unit is specified, consumer may apply heuristic to deduce the unit.
+    /// Consumers may also  interpret units like "bytes" and "kilobytes" as memory
+    /// units and units like "seconds" and "nanoseconds" as time units,
+    /// and apply appropriate unit conversions to these.
+    ///
+    /// Index into string table
+    #[prost(int64, tag="4")]
+    pub num_unit: i64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Mapping {
+    /// Unique nonzero id for the mapping.
+    #[prost(uint64, tag="1")]
+    pub id: u64,
+    /// Address at which the binary (or DLL) is loaded into memory.
+    #[prost(uint64, tag="2")]
+    pub memory_start: u64,
+    /// The limit of the address range occupied by this mapping.
+    #[prost(uint64, tag="3")]
+    pub memory_limit: u64,
+    /// Offset in the binary that corresponds to the first mapped address.
+    #[prost(uint64, tag="4")]
+    pub file_offset: u64,
+    /// The object this entry is loaded from.  This can be a filename on
+    /// disk for the main binary and shared libraries, or virtual
+    /// abstractions like "\[vdso\]".
+    ///
+    /// Index into string table
+    #[prost(int64, tag="5")]
+    pub filename: i64,
+    /// A string that uniquely identifies a particular program version
+    /// with high probability. E.g., for binaries generated by GNU tools,
+    /// it could be the contents of the .note.gnu.build-id field.
+    ///
+    /// Index into string table
+    #[prost(int64, tag="6")]
+    pub build_id: i64,
+    /// The following fields indicate the resolution of symbolic info.
+    #[prost(bool, tag="7")]
+    pub has_functions: bool,
+    #[prost(bool, tag="8")]
+    pub has_filenames: bool,
+    #[prost(bool, tag="9")]
+    pub has_line_numbers: bool,
+    #[prost(bool, tag="10")]
+    pub has_inline_frames: bool,
+}
+/// Describes function and line table debug information.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Location {
+    /// Unique nonzero id for the location.  A profile could use
+    /// instruction addresses or any integer sequence as ids.
+    #[prost(uint64, tag="1")]
+    pub id: u64,
+    /// The id of the corresponding profile.Mapping for this location.
+    /// It can be unset if the mapping is unknown or not applicable for
+    /// this profile type.
+    #[prost(uint64, tag="2")]
+    pub mapping_id: u64,
+    /// The instruction address for this location, if available.  It
+    /// should be within \[Mapping.memory_start...Mapping.memory_limit\]
+    /// for the corresponding mapping. A non-leaf address may be in the
+    /// middle of a call instruction. It is up to display tools to find
+    /// the beginning of the instruction if necessary.
+    #[prost(uint64, tag="3")]
+    pub address: u64,
+    /// Multiple line indicates this location has inlined functions,
+    /// where the last entry represents the caller into which the
+    /// preceding entries were inlined.
+    ///
+    /// E.g., if memcpy() is inlined into printf:
+    ///    line\[0\].function_name == "memcpy"
+    ///    line\[1\].function_name == "printf"
+    #[prost(message, repeated, tag="4")]
+    pub line: ::prost::alloc::vec::Vec<Line>,
+    /// Provides an indication that multiple symbols map to this location's
+    /// address, for example due to identical code folding by the linker. In that
+    /// case the line information above represents one of the multiple
+    /// symbols. This field must be recomputed when the symbolization state of the
+    /// profile changes.
+    #[prost(bool, tag="5")]
+    pub is_folded: bool,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Line {
+    /// The id of the corresponding profile.Function for this line.
+    #[prost(uint64, tag="1")]
+    pub function_id: u64,
+    /// Line number in source code.
+    #[prost(int64, tag="2")]
+    pub line: i64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Function {
+    /// Unique nonzero id for the function.
+    #[prost(uint64, tag="1")]
+    pub id: u64,
+    /// Name of the function, in human-readable form if available.
+    ///
+    /// Index into string table
+    #[prost(int64, tag="2")]
+    pub name: i64,
+    /// Name of the function, as identified by the system.
+    /// For instance, it can be a C++ mangled name.
+    ///
+    /// Index into string table
+    #[prost(int64, tag="3")]
+    pub system_name: i64,
+    /// Source file containing the function.
+    ///
+    /// Index into string table
+    #[prost(int64, tag="4")]
+    pub filename: i64,
+    /// Line number in source file.
+    #[prost(int64, tag="5")]
+    pub start_line: i64,
+}

--- a/src/ui/pprof.rs
+++ b/src/ui/pprof.rs
@@ -1,0 +1,439 @@
+use flate2::{write::GzEncoder, Compression};
+use std::collections::HashMap;
+use std::io::prelude::*;
+use std::time::SystemTime;
+
+use crate::core::types::{StackFrame, StackTrace};
+
+use anyhow::Result;
+
+use prost::Message; // for encode and decode methods below
+
+pub mod pprofs {
+    include!("perftools.profiles.rs");
+}
+use self::pprofs::{Function, Label, Line, Location, Profile, Sample, ValueType};
+
+#[derive(Default)]
+pub struct Stats {
+    profile: Profile,
+    known_frames: HashMap<StackFrame, u64>,
+    prev_time: Option<SystemTime>,
+}
+
+impl Stats {
+    pub fn new() -> Stats {
+        Stats {
+            profile: Profile {
+                // string index 0 must point to "" according to the .proto spec, while "wall" and "ns" are for our sample_type field
+                string_table: vec!["".to_string(), "wall".to_string(), "ns".to_string()],
+                sample_type: vec![ValueType { r#type: 1, unit: 2 }], // 1 and 2 are indexes from string_table
+                ..Profile::default()
+            },
+            ..Stats::default()
+        }
+    }
+
+    pub fn record(&mut self, stack: &StackTrace) -> Result<()> {
+        let this_time = stack.time.unwrap_or_else(SystemTime::now);
+        let ns_since_last_sample = match self.prev_time {
+            Some(prev_time) => this_time.duration_since(prev_time)?.as_nanos(),
+            None => 0,
+        } as i64;
+        self.add_sample(stack, ns_since_last_sample);
+        self.prev_time = Some(this_time);
+        Ok(())
+    }
+
+    fn add_sample(&mut self, stack: &StackTrace, sample_time: i64) {
+        let s = Sample {
+            location_id: self.location_ids(stack),
+            value: vec![sample_time],
+            label: self.labels(stack),
+        };
+        self.profile.sample.push(s);
+    }
+
+    fn location_ids(&mut self, stack: &StackTrace) -> Vec<u64> {
+        let mut ids = <Vec<u64>>::new();
+
+        for frame in &stack.trace {
+            ids.push(self.get_or_create_location_id(frame));
+        }
+        ids
+    }
+
+    fn get_or_create_location_id(&mut self, frame: &StackFrame) -> u64 {
+        // our lookup table has the arbitrary ids (1..n) we use for location ids
+        if let Some(id) = self.known_frames.get(frame) {
+            *id
+        } else {
+            let next_id = self.known_frames.len() as u64 + 1; //ids must be non-0, so start at 1
+            self.known_frames.insert(frame.clone(), next_id); // add to our lookup table
+            let newloc = self.new_location(next_id, frame); // use the same id for the location table
+            self.profile.location.push(newloc);
+            next_id
+        }
+    }
+
+    fn new_location(&mut self, id: u64, frame: &StackFrame) -> Location {
+        let new_line = Line {
+            function_id: self.get_or_create_function_id(frame),
+            line: frame.lineno as i64,
+        };
+        Location {
+            id,
+            line: vec![new_line],
+            ..Location::default()
+        }
+    }
+
+    fn get_or_create_function_id(&mut self, frame: &StackFrame) -> u64 {
+        let strings = &self.profile.string_table;
+        let mut functions = self.profile.function.iter();
+        if let Some(function) = functions.find(|f| {
+            frame.name == strings[f.name as usize]
+                && frame.relative_path == strings[f.filename as usize]
+        }) {
+            function.id
+        } else {
+            let functions = self.profile.function.iter();
+            let mapped_iter = functions.map(|f| f.id);
+            let max_map = mapped_iter.max();
+            let next_id = match max_map {
+                Some(id) => id + 1,
+                None => 1,
+            };
+            let f = self.new_function(next_id, frame);
+            self.profile.function.push(f);
+            next_id
+        }
+    }
+
+    fn new_function(&mut self, id: u64, frame: &StackFrame) -> Function {
+        Function {
+            id,
+            name: self.string_id(&frame.name),
+            filename: self.string_id(&frame.relative_path),
+            ..Function::default()
+        }
+    }
+
+    fn string_id(&mut self, text: &str) -> i64 {
+        let strings = &mut self.profile.string_table;
+        if let Some(id) = strings.iter().position(|s| *s == *text) {
+            id as i64
+        } else {
+            let next_id = strings.len() as i64;
+            strings.push((*text).to_owned());
+            next_id
+        }
+    }
+
+    fn labels(&mut self, stack: &StackTrace) -> Vec<Label> {
+        let mut labels: Vec<Label> = Vec::new();
+        if let Some(pid) = stack.pid {
+            labels.push(Label {
+                key: self.string_id(&"pid".to_string()),
+                num: pid as i64,
+                ..Label::default()
+            });
+        }
+        if let Some(thread_id) = stack.thread_id {
+            labels.push(Label {
+                key: self.string_id(&"thread_id".to_string()),
+                num: thread_id as i64,
+                ..Label::default()
+            });
+        }
+        labels
+    }
+
+    pub fn write(&mut self, w: &mut dyn Write) -> Result<()> {
+        let mut pprof_data = Vec::new();
+        let mut gzip = GzEncoder::new(Vec::new(), Compression::default());
+
+        self.profile.encode(&mut pprof_data)?;
+        gzip.write_all(&pprof_data)?;
+        w.write_all(&gzip.finish()?)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ui::pprof::*;
+    use flate2::read::GzDecoder;
+    use std::time::Duration;
+
+    // Build a test stacktrace
+    fn s(frames: Vec<StackFrame>, time: SystemTime) -> StackTrace {
+        StackTrace {
+            trace: frames,
+            pid: Some(9),
+            thread_id: Some(999),
+            time: Some(time),
+        }
+    }
+
+    // Build a test stackframe
+    fn f(i: u32) -> StackFrame {
+        StackFrame {
+            name: format!("func{}", i),
+            relative_path: format!("file{}.rb", i),
+            absolute_path: None,
+            lineno: i,
+        }
+    }
+
+    // A stack frame from the same file as another one
+    fn fdup() -> StackFrame {
+        StackFrame {
+            name: "funcX".to_owned(),
+            relative_path: "file1.rb".to_owned(),
+            absolute_path: None,
+            lineno: 42,
+        }
+    }
+
+    fn test_stats() -> Stats {
+        let mut stats = Stats::new();
+        let mut time = SystemTime::now();
+        stats.record(&s(vec![f(1)], time)).unwrap();
+        time += Duration::new(0, 200);
+        stats.record(&s(vec![f(3), f(2), f(1)], time)).unwrap();
+        time += Duration::new(0, 400);
+        stats.record(&s(vec![f(2), f(1)], time)).unwrap();
+        time += Duration::new(0, 600);
+        stats.record(&s(vec![f(3), f(1)], time)).unwrap();
+        time += Duration::new(0, 800);
+        stats.record(&s(vec![f(2), f(1)], time)).unwrap();
+        time += Duration::new(0, 1000);
+        stats.record(&s(vec![f(3), fdup(), f(1)], time)).unwrap();
+
+        stats
+    }
+
+    #[test]
+    fn can_collect_traces_and_write_to_pprof_format() {
+        let mut gz_stats_buf: Vec<u8> = Vec::new();
+        let mut stats = test_stats();
+        stats.write(&mut gz_stats_buf).expect("write failed");
+
+        let mut gz = GzDecoder::new(&*gz_stats_buf);
+        let mut stats_buf = Vec::new();
+        gz.read_to_end(&mut stats_buf).unwrap();
+
+        let actual = pprofs::Profile::decode(&*stats_buf).expect("decode failed");
+        let expected = Profile {
+            sample_type: vec![ValueType { r#type: 1, unit: 2 }],
+            sample: vec![
+                Sample {
+                    location_id: vec![1],
+                    value: vec![0],
+                    label: vec![
+                        Label {
+                            key: 5,
+                            str: 0,
+                            num: 9,
+                            num_unit: 0,
+                        },
+                        Label {
+                            key: 6,
+                            str: 0,
+                            num: 999,
+                            num_unit: 0,
+                        },
+                    ],
+                },
+                Sample {
+                    location_id: vec![2, 3, 1],
+                    value: vec![200],
+                    label: vec![
+                        Label {
+                            key: 5,
+                            str: 0,
+                            num: 9,
+                            num_unit: 0,
+                        },
+                        Label {
+                            key: 6,
+                            str: 0,
+                            num: 999,
+                            num_unit: 0,
+                        },
+                    ],
+                },
+                Sample {
+                    location_id: vec![3, 1],
+                    value: vec![400],
+                    label: vec![
+                        Label {
+                            key: 5,
+                            str: 0,
+                            num: 9,
+                            num_unit: 0,
+                        },
+                        Label {
+                            key: 6,
+                            str: 0,
+                            num: 999,
+                            num_unit: 0,
+                        },
+                    ],
+                },
+                Sample {
+                    location_id: vec![2, 1],
+                    value: vec![600],
+                    label: vec![
+                        Label {
+                            key: 5,
+                            str: 0,
+                            num: 9,
+                            num_unit: 0,
+                        },
+                        Label {
+                            key: 6,
+                            str: 0,
+                            num: 999,
+                            num_unit: 0,
+                        },
+                    ],
+                },
+                Sample {
+                    location_id: vec![3, 1],
+                    value: vec![800],
+                    label: vec![
+                        Label {
+                            key: 5,
+                            str: 0,
+                            num: 9,
+                            num_unit: 0,
+                        },
+                        Label {
+                            key: 6,
+                            str: 0,
+                            num: 999,
+                            num_unit: 0,
+                        },
+                    ],
+                },
+                Sample {
+                    location_id: vec![2, 4, 1],
+                    value: vec![1000],
+                    label: vec![
+                        Label {
+                            key: 5,
+                            str: 0,
+                            num: 9,
+                            num_unit: 0,
+                        },
+                        Label {
+                            key: 6,
+                            str: 0,
+                            num: 999,
+                            num_unit: 0,
+                        },
+                    ],
+                },
+            ],
+            mapping: vec![],
+            location: vec![
+                Location {
+                    id: 1,
+                    mapping_id: 0,
+                    address: 0,
+                    line: vec![Line {
+                        function_id: 1,
+                        line: 1,
+                    }],
+                    is_folded: false,
+                },
+                Location {
+                    id: 2,
+                    mapping_id: 0,
+                    address: 0,
+                    line: vec![Line {
+                        function_id: 2,
+                        line: 3,
+                    }],
+                    is_folded: false,
+                },
+                Location {
+                    id: 3,
+                    mapping_id: 0,
+                    address: 0,
+                    line: vec![Line {
+                        function_id: 3,
+                        line: 2,
+                    }],
+                    is_folded: false,
+                },
+                Location {
+                    id: 4,
+                    mapping_id: 0,
+                    address: 0,
+                    line: vec![Line {
+                        function_id: 4,
+                        line: 42,
+                    }],
+                    is_folded: false,
+                },
+            ],
+            function: vec![
+                Function {
+                    id: 1,
+                    name: 3,
+                    system_name: 0,
+                    filename: 4,
+                    start_line: 0,
+                },
+                Function {
+                    id: 2,
+                    name: 7,
+                    system_name: 0,
+                    filename: 8,
+                    start_line: 0,
+                },
+                Function {
+                    id: 3,
+                    name: 9,
+                    system_name: 0,
+                    filename: 10,
+                    start_line: 0,
+                },
+                Function {
+                    id: 4,
+                    name: 11,
+                    system_name: 0,
+                    filename: 4,
+                    start_line: 0,
+                },
+            ],
+            string_table: vec![
+                "".to_string(),
+                "wall".to_string(),
+                "ns".to_string(),
+                "func1".to_string(),
+                "file1.rb".to_string(),
+                "pid".to_string(),
+                "thread_id".to_string(),
+                "func3".to_string(),
+                "file3.rb".to_string(),
+                "func2".to_string(),
+                "file2.rb".to_string(),
+                "funcX".to_string(),
+            ],
+            drop_frames: 0,
+            keep_frames: 0,
+            time_nanos: 0,
+            duration_nanos: 0,
+            period_type: None,
+            period: 0,
+            comment: vec![],
+            default_sample_type: 0,
+        };
+        assert_eq!(actual, expected, "stats don't match");
+    }
+}


### PR DESCRIPTION
This adds a new outputter to support the trace output format described here: https://github.com/google/pprof/tree/master/proto.  This is a format typically used to profile golang programs.  It can be used to upload traces to [Google Cloud Profiler](https://cloud.google.com/profiler), and [Speedscope also supports it](https://github.com/jlfwong/speedscope/wiki/Importing-from-pprof-(go)).

I've closely followed the approach used to add Speedscope support, so most of it should be fairly self-explanatory.

~In the first commit, I've also done some refactoring in `Recorder::record()` to expand the API a bit without changing functionality.  This was helpful in implementing an additional `Recorder` trait for another project I'm working on.  If this change is undesirable, the `pprof`-related code should work the same without it.~ (See comment below)