### PR TITLE
Enhance the user experience in pprof-consuming apps by adjusting units

### DIFF
--- a/src/ui/pprof.rs
+++ b/src/ui/pprof.rs
@@ -25,8 +25,12 @@ impl Stats {
     pub fn new() -> Stats {
         Stats {
             profile: Profile {
-                // string index 0 must point to "" according to the .proto spec, while "wall" and "ns" are for our sample_type field
-                string_table: vec!["".to_string(), "wall".to_string(), "ns".to_string()],
+                // string index 0 must point to "" according to the .proto spec, while "wall" and "nanoseconds" are for our sample_type field
+                string_table: vec![
+                    "".to_string(),
+                    "wall".to_string(),
+                    "nanoseconds".to_string(),
+                ],
                 sample_type: vec![ValueType { r#type: 1, unit: 2 }], // 1 and 2 are indexes from string_table
                 ..Profile::default()
             },
@@ -414,7 +418,7 @@ mod test {
             string_table: vec![
                 "".to_string(),
                 "wall".to_string(),
-                "ns".to_string(),
+                "nanoseconds".to_string(),
                 "func1".to_string(),
                 "file1.rb".to_string(),
                 "pid".to_string(),


### PR DESCRIPTION
Although any arbitrary string can be used for `sample_type` units in pprof format, I've accidentally learned that the user experience in Google Cloud Profiler and Speedscope can be improved by specifying these units as "nanoseconds".  When using "ns" we see large numbers with a lot of commas everywhere, but by changing to "nanoseconds" we get automatically scaled display units like "ms" and "s".

Before and after (different samples):

<img width="400" alt="Screen Shot 2021-12-19 at 4 21 09 PM" src="https://user-images.githubusercontent.com/16967828/146701417-1efe2d26-08e0-4b6b-b7d5-921a893f54ee.png"><img width="400" alt="Screen Shot 2021-12-19 at 4 20 25 PM" src="https://user-images.githubusercontent.com/16967828/146701403-5a18c597-4124-479a-987c-7e77838af049.png">

