### PR TITLE
refactor: export StackTrace type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod ui;
 
 pub use crate::core::process::Pid;
 pub use crate::core::types::OutputFormat;
+pub use crate::core::types::StackTrace;
 
 /// Generate visualization (e.g. a flamegraph) from raw data that was previously recorded by rbspy
 pub fn report(


### PR DESCRIPTION
Any reason why these types are private? I'm integrating rbspy with https://github.com/pyroscope-io/pyroscope-rs and they could be useful. So far, I'm using StackTrace, but I think more types could be exposed.