### PR TITLE
Add --force-version flag for testing with pre-release rubies

### DIFF
--- a/examples/record.rs
+++ b/examples/record.rs
@@ -20,6 +20,7 @@ fn main() {
         maybe_duration: Some(std::time::Duration::from_secs(1)),
         flame_min_width: 10.0,
         lock_process: true,
+        force_version: None,
     };
     let recorder = Recorder::new(config);
     match recorder.record() {

--- a/examples/snapshot.rs
+++ b/examples/snapshot.rs
@@ -9,7 +9,7 @@ fn main() {
         .unwrap();
     let pid = process.id() as rbspy::Pid;
 
-    match snapshot(pid, true) {
+    match snapshot(pid, true, None) {
         Ok(s) => println!("{}", s),
         Err(e) => println!("Failed to get snapshot: {:?}", e),
     }

--- a/src/core/initialize.rs
+++ b/src/core/initialize.rs
@@ -361,7 +361,7 @@ fn is_maybe_thread_function(version: &str) -> IsMaybeThreadFn {
         "3.1.0" => ruby_version::ruby_3_1_0::is_maybe_thread,
         "3.1.1" => ruby_version::ruby_3_1_1::is_maybe_thread,
         _ => panic!(
-            "Ruby version not supported yet: {}. Please create a GitHub issue and we'll fix it!",
+            "The target process's Ruby version is not supported yet. In the meantime, you can try using `--force-version {}`.",
             version
         ),
     };
@@ -449,7 +449,7 @@ fn get_stack_trace_function(version: &str) -> StackTraceFn {
         "3.1.0" => ruby_version::ruby_3_1_0::get_stack_trace,
         "3.1.1" => ruby_version::ruby_3_1_1::get_stack_trace,
         _ => panic!(
-            "Ruby version not supported yet: {}. Please create a GitHub issue and we'll fix it!",
+            "The target process's Ruby version is not supported yet. In the meantime, you can try using `--force-version {}`.",
             version
         ),
     };

--- a/src/recorder/record.rs
+++ b/src/recorder/record.rs
@@ -36,6 +36,11 @@ pub struct Config {
     /// stops the process from executing and can affect performance. The performance impact
     /// is most noticeable in CPU-bound ruby programs or when a high sampling rate is used.
     pub lock_process: bool,
+    /// Forces the recorder to use the given Ruby version. If not given, rbspy will attempt to
+    /// determine the Ruby version from the running process.
+    ///
+    /// This option shouldn't be needed unless you're testing a pre-release Ruby version.
+    pub force_version: Option<String>,
 }
 
 pub struct Recorder {
@@ -56,6 +61,7 @@ impl Recorder {
             config.lock_process,
             config.maybe_duration,
             config.with_subprocesses,
+            config.force_version,
         );
 
         Recorder {

--- a/src/recorder/snapshot.rs
+++ b/src/recorder/snapshot.rs
@@ -4,7 +4,11 @@ use crate::core::types::StackTrace;
 use anyhow::{Error, Result};
 
 /// Captures a single trace from the process belonging to `pid`
-pub fn snapshot(pid: Pid, lock_process: bool) -> Result<StackTrace, Error> {
-    let mut getter = initialize(pid, lock_process)?;
+pub fn snapshot(
+    pid: Pid,
+    lock_process: bool,
+    force_version: Option<String>,
+) -> Result<StackTrace, Error> {
+    let mut getter = initialize(pid, lock_process, force_version)?;
     getter.get_trace()
 }


### PR DESCRIPTION
Testing new versions of ruby before they're released is currently a bit of a pain. You need to mention the new version string(s) in a few places, run bindgen, and recompile. However, breaking changes to the ruby C types that rbspy cares about are fairly rare, and using the types from the previous ruby version usually works fine. This PR adds a `--force-version` flag that overrides the version detection that rbspy normally performs.

The flag might also be useful for anyone maintaining a custom ruby build that has a unique version string but is otherwise compatible with upstream ruby.

For example, I have ruby 3.1.1 installed on my computer, and today I wanted to check rbspy's compatibility with [3.2.0 preview 1](https://www.ruby-lang.org/en/news/2022/04/03/ruby-3-2-0-preview1-released/) that was just released. With the new flag, it's easy:

```
$ ruby -v
ruby 3.2.0dev (2022-04-03T15:09:54Z master fb5aa31e2d) [arm64-darwin21]

$ ruby ci/ruby-programs/infinite.rb &
[1] 84631

$ sudo ./target/debug/rbspy snapshot --pid $(pgrep ruby)
Password:
thread 'main' panicked at 'Ruby version not supported yet: 3.2.0. Please create a GitHub issue and we'll fix it!', src/core/initialize.rs:451:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

$ sudo ./target/debug/rbspy snapshot --pid $(pgrep ruby) --force-version 3.1.1
<main> - /Users/acj/proj/rbspy/rbspy/ci/ruby-programs/infinite.rb:13
loop [c function] - (unknown):0
block in <main> - /Users/acj/proj/rbspy/rbspy/ci/ruby-programs/infinite.rb:15
ccc - /Users/acj/proj/rbspy/rbspy/ci/ruby-programs/infinite.rb:11
bbb - /Users/acj/proj/rbspy/rbspy/ci/ruby-programs/infinite.rb:7
aaa - /Users/acj/proj/rbspy/rbspy/ci/ruby-programs/infinite.rb:3
sleep [c function] - (unknown):0
```

As a followup step, I'd like to set up a CI job that runs ~weekly against ruby's development branch so that we'll be warned about breaking changes well before a release.