### PR TITLE
pprof: Tolerate stack frame timestamps arriving out of order

### DIFF
--- a/src/ui/pprof.rs
+++ b/src/ui/pprof.rs
@@ -41,7 +41,15 @@ impl Stats {
     pub fn record(&mut self, stack: &StackTrace) -> Result<()> {
         let this_time = stack.time.unwrap_or_else(SystemTime::now);
         let ns_since_last_sample = match self.prev_time {
-            Some(prev_time) => this_time.duration_since(prev_time)?.as_nanos(),
+            Some(prev_time) => match this_time.duration_since(prev_time) {
+                Ok(duration) => duration.as_nanos(),
+                Err(e) => {
+                    // It's possible that samples will arrive out of order, e.g. if we're sampling
+                    // from multiple processes.
+                    warn!("sample arrived out of order: {}", e);
+                    0
+                }
+            },
             None => 0,
         } as i64;
         self.add_sample(stack, ns_since_last_sample);

--- a/src/ui/pprof.rs
+++ b/src/ui/pprof.rs
@@ -220,6 +220,15 @@ mod test {
     }
 
     #[test]
+    fn tolerate_stacktrace_timestamps_arriving_out_of_order() {
+        let mut stats = Stats::new();
+        let mut time = SystemTime::now();
+        stats.record(&s(vec![f(1)], time)).unwrap();
+        time -= Duration::new(0, 200);
+        stats.record(&s(vec![f(3), f(2), f(1)], time)).unwrap();
+    }
+
+    #[test]
     fn can_collect_traces_and_write_to_pprof_format() {
         let mut gz_stats_buf: Vec<u8> = Vec::new();
         let mut stats = test_stats();


### PR DESCRIPTION
Resolves #367. When sampling multiple processes, the order in which the samples arrive at the stats recorder is nondeterministic. That can result in awkward calculations where the previous sample seems to have arrived after the current one.

There are several options for handling this. We could drop the current sample, or calculate the elapsed time backwards (treat the previous time as the next one), or assume that the timestamps arrived at the same time, etc. This workaround uses the latter. That is, we assume that no time has elapsed between the "previous" sample and the one that we're currently processing.

@saunderst, WDYT?