### PR TITLE
Implement native profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ca9b76e919fd83ccfb509f51b28c333c0e03f2221616e347a129215cec4e4a9"
 dependencies = [
- "cpp_demangle",
+ "cpp_demangle 0.3.5",
  "fallible-iterator",
- "gimli",
+ "gimli 0.26.2",
  "object",
  "rustc-demangle",
  "smallvec",
@@ -90,6 +90,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "binary-merge"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
+
+[[package]]
 name = "bindgen"
 version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +168,27 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "brownstone"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5839ee4f953e811bfdcf223f509cb2c6a3e1447959b0bff459405575bc17f22"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "bumpalo"
@@ -320,6 +347,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b446fd40bcc17eddd6a4a78f24315eb90afdb3334999ddfd4909985c47722442"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +451,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "directories"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,10 +480,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dmsort"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0bc8fbe9441c17c9f46f75dfe27fa1ddb6c68a461ccaed0481419219d4f10d3"
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "elementtree"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e91f812124e4fc7f82605feda4da357307185a4619baee415ae0b7f6d5e031"
+dependencies = [
+ "string_cache",
+]
 
 [[package]]
 name = "elf"
@@ -447,6 +507,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4841de15dbe0e49b9b62a417589299e3be0d557e0900d36acb87e6dae47197f5"
 dependencies = [
  "byteorder 0.5.3",
+]
+
+[[package]]
+name = "elsa"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4b5d23ed6b6948d68240aafa4ac98e568c9a020efd9d4201a6288bc3006e09"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -500,10 +569,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "getrandom"
@@ -521,6 +605,16 @@ name = "gimli"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+dependencies = [
+ "fallible-iterator",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 dependencies = [
  "fallible-iterator",
  "stable_deref_trait",
@@ -606,6 +700,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indent_write"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +750,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inplace-vec-builder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +772,12 @@ name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+
+[[package]]
+name = "joinery"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "js-sys"
@@ -674,6 +799,12 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -765,6 +896,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e854583a83f20cf329bb9283366335387f7db59d640d1412167e05fedb98826"
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +951,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "msvc-demangler"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb67c6dd0fa9b00619c41c5700b6f92d5f418be49b45ddb9970fbd4569df3c8"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
 name = "nix"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +998,19 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom-supreme"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd3ae6c901f1959588759ff51c95d24b491ecb9ff91aa9c2ef4acc5b1dcab27"
+dependencies = [
+ "brownstone",
+ "indent_write",
+ "joinery",
+ "memchr",
+ "nom",
 ]
 
 [[package]]
@@ -910,6 +1075,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,10 +1098,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdb"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82040a392923abe6279c00ab4aff62d5250d1c8555dc780e4b02783a7aa74863"
+dependencies = [
+ "fallible-iterator",
+ "scroll",
+ "uuid",
+]
+
+[[package]]
+name = "pdb-addr2line"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e89a9f2f40b2389ba6da0814c8044bf942bece03dffa1514f84e3b525f4f9a"
+dependencies = [
+ "bitflags",
+ "elsa",
+ "maybe-owned",
+ "pdb",
+ "range-collections",
+ "thiserror",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-utils"
@@ -945,6 +1160,12 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-error"
@@ -1049,6 +1270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +1334,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-collections"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fdfd79629e2b44a1d34b4d227957174cb858e6b86ee45fad114edbcfc903ab"
+dependencies = [
+ "binary-merge",
+ "inplace-vec-builder",
+ "smallvec",
+]
+
+[[package]]
 name = "rbspy"
 version = "0.14.0"
 dependencies = [
@@ -1137,6 +1375,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spytools",
+ "symbolic",
  "tempdir",
  "term_size",
  "thiserror",
@@ -1320,6 +1559,9 @@ name = "serde"
 version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -1348,6 +1590,12 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "smallvec"
@@ -1385,6 +1633,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
+name = "string_cache"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1659,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "symbolic"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4e804a19ea4039205b426738671552a7f6bec75015e0437f6318ddb4fb5123c"
+dependencies = [
+ "symbolic-common",
+ "symbolic-debuginfo",
+ "symbolic-demangle",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b55cdc318ede251d0957f07afe5fed912119b8c1bc5a7804151826db999e737"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-debuginfo"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f5d898f6c19efe593df62197f91df6176bdfa664426b16ff9f1a434a83df67"
+dependencies = [
+ "bitvec",
+ "dmsort",
+ "elementtree",
+ "elsa",
+ "fallible-iterator",
+ "flate2",
+ "gimli 0.27.0",
+ "goblin 0.6.0",
+ "lazy_static",
+ "lazycell",
+ "nom",
+ "nom-supreme",
+ "parking_lot",
+ "pdb-addr2line",
+ "regex",
+ "scroll",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "symbolic-common",
+ "symbolic-ppdb",
+ "thiserror",
+ "wasmparser",
+ "zip",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79be897be8a483a81fff6a3a4e195b4ac838ef73ca42d348b3f722da9902e489"
+dependencies = [
+ "cc",
+ "cpp_demangle 0.4.0",
+ "msvc-demangler",
+ "rustc-demangle",
+ "symbolic-common",
+]
+
+[[package]]
+name = "symbolic-ppdb"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125fcd987182e46cd828416a9f2bdb7752c42081b33fa6d80a94afb1fdd4109b"
+dependencies = [
+ "indexmap",
+ "symbolic-common",
+ "thiserror",
+ "uuid",
+ "watto",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1749,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempdir"
@@ -1483,16 +1832,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 
 [[package]]
 name = "vec_map"
@@ -1571,6 +1967,26 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "wasmparser"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
+dependencies = [
+ "indexmap",
+ "url",
+]
+
+[[package]]
+name = "watto"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6746b5315e417144282a047ebb82260d45c92d09bf653fa9ec975e3809be942b"
+dependencies = [
+ "leb128",
+ "thiserror",
+]
 
 [[package]]
 name = "which"
@@ -1672,6 +2088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "xtask"
 version = "0.13.0"
 dependencies = [
@@ -1679,4 +2104,16 @@ dependencies = [
  "bindgen 0.61.0",
  "log",
  "tempdir",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
+dependencies = [
+ "byteorder 1.4.3",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ proc-maps = "0.3.0"
 prost = "0.11.0"
 rand = "0.8.3"
 rbspy-ruby-structs = { path = "ruby-structs", version="0.14.0" }
-remoteprocess = "0.4.5"
+remoteprocess = { version = "0.4.5", features = ["unwind"] }
 semver = "1.0.10"
 serde = "1.0.131"
 serde_derive = "1.0.131"
@@ -46,6 +46,7 @@ spytools = "0.1.3"
 term_size = "0.3.2"
 tempdir = "0.3.7"
 thiserror = "1.0.24"
+symbolic = { version = "10.2.1", features = ["demangle"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.25.0"
@@ -60,6 +61,3 @@ winapi = { version = "0.3.9", features = ["timeapi", "wow64apiset"] }
 byteorder = "1.4.3"
 rbspy-testdata = "0.1.5"
 tempdir = "0.3.4"
-
-[features]
-native_profiling = ["remoteprocess/unwind"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,6 @@ winapi = { version = "0.3.9", features = ["timeapi", "wow64apiset"] }
 byteorder = "1.4.3"
 rbspy-testdata = "0.1.5"
 tempdir = "0.3.4"
+
+[features]
+native_profiling = ["remoteprocess/unwind"]

--- a/examples/record.rs
+++ b/examples/record.rs
@@ -23,7 +23,7 @@ fn main() {
         flame_min_width: 10.0,
         lock_process: true,
         force_version: None,
-        native_tracing: false
+        native_profiling: false,
     };
     let recorder = Recorder::new(config);
     match recorder.record() {

--- a/examples/record.rs
+++ b/examples/record.rs
@@ -23,6 +23,7 @@ fn main() {
         flame_min_width: 10.0,
         lock_process: true,
         force_version: None,
+        native_tracing: false
     };
     let recorder = Recorder::new(config);
     match recorder.record() {

--- a/src/core/ruby_spy.rs
+++ b/src/core/ruby_spy.rs
@@ -190,15 +190,7 @@ impl RubySpy {
                     .unwrap_or_else(|| "cfunc (unnamed)".into());
                 let name = Name::from(name);
                 let name = name.try_demangle(DemangleOptions::complete());
-                if sf
-                    .filename
-                    .as_ref()
-                    .map(|s| s as &str)
-                    .unwrap_or_default()
-                    .contains("ruby")
-                {
-                    return;
-                }
+
                 native_frames.push(StackFrame {
                     name: name.into(),
                     relative_path: sf.filename.clone().unwrap_or_default(),
@@ -256,7 +248,8 @@ fn merge_ruby_and_native_frames(
                     break;
                 }
 
-                if found_start_of_cfunc {
+                // TODO: find a way to filter out internal ruby core functions, and make it configurable?
+                if found_start_of_cfunc  {
                     frames.push(native_frame.clone());
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ enum SubCmd {
         flame_min_width: f64,
         lock_process: bool,
         force_version: Option<String>,
-        native_tracing: bool
+        native_profiling: bool,
     },
     /// Capture and print a stacktrace snapshot of process `pid`.
     Snapshot {
@@ -123,7 +123,7 @@ fn do_main() -> Result<(), Error> {
             flame_min_width,
             lock_process,
             force_version,
-            native_tracing
+            native_profiling,
         } => {
             let pid = match target {
                 Target::Pid { pid } => pid,
@@ -188,7 +188,7 @@ fn do_main() -> Result<(), Error> {
                 flame_min_width,
                 lock_process,
                 force_version,
-                native_tracing
+                native_profiling,
             };
 
             let recorder = Arc::<recorder::Recorder>::new(recorder::Recorder::new(config));
@@ -372,9 +372,9 @@ fn arg_parser() -> clap::Command<'static> {
                         .required(false)
                 )
                 .arg(
-                    clap::Arg::new("native_tracing")
+                    clap::Arg::new("native-profiling")
                         .help("Enable profiling from the native stack")
-                        .long("native_tracing")
+                        .long("native-profiling")
                         .required(false),
                 )
                 .arg(arg!(<cmd> ... "command to run").required(false)),
@@ -446,7 +446,7 @@ impl Args {
                 };
 
                 let no_drop_root = submatches.occurrences_of("no-drop-root") == 1;
-                let native_tracing = submatches.occurrences_of("native_tracing") == 1;
+                let native_profiling = submatches.occurrences_of("native-profiling") == 1;
 
                 let silent = submatches.is_present("silent");
                 let with_subprocesses = submatches.is_present("subprocesses");
@@ -483,7 +483,7 @@ impl Args {
                     flame_min_width,
                     lock_process: !nonblocking,
                     force_version,
-                    native_tracing
+                    native_profiling,
                 }
             }
             Some(("report", submatches)) => {
@@ -607,7 +607,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: true,
                     force_version: None,
-                    native_tracing: false
+                    native_profiling: false
                 },
             }
         );
@@ -632,7 +632,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: true,
                     force_version: None,
-                    native_tracing: false
+                    native_profiling: false
                 },
             }
         );
@@ -657,7 +657,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: true,
                     force_version: None,
-                    native_tracing: false
+                    native_profiling: false
                 },
             }
         );
@@ -681,7 +681,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: true,
                     force_version: None,
-                    native_tracing: false
+                    native_profiling: false
                 },
             }
         );
@@ -706,7 +706,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: true,
                     force_version: None,
-                    native_tracing: false
+                    native_profiling: false
                 },
             }
         );
@@ -731,7 +731,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: true,
                     force_version: None,
-                    native_tracing: false
+                    native_profiling: false
                 },
             }
         );
@@ -756,7 +756,7 @@ mod tests {
                     flame_min_width: 0.02,
                     lock_process: true,
                     force_version: None,
-                    native_tracing: false
+                    native_profiling: false
                 },
             }
         );
@@ -781,7 +781,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: false,
                     force_version: None,
-                    native_tracing: false
+                    native_profiling: false
                 },
             }
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ enum SubCmd {
         flame_min_width: f64,
         lock_process: bool,
         force_version: Option<String>,
+        native_tracing: bool
     },
     /// Capture and print a stacktrace snapshot of process `pid`.
     Snapshot {
@@ -122,6 +123,7 @@ fn do_main() -> Result<(), Error> {
             flame_min_width,
             lock_process,
             force_version,
+            native_tracing
         } => {
             let pid = match target {
                 Target::Pid { pid } => pid,
@@ -186,6 +188,7 @@ fn do_main() -> Result<(), Error> {
                 flame_min_width,
                 lock_process,
                 force_version,
+                native_tracing
             };
 
             let recorder = Arc::<recorder::Recorder>::new(recorder::Recorder::new(config));
@@ -368,6 +371,12 @@ fn arg_parser() -> clap::Command<'static> {
                         .takes_value(true)
                         .required(false)
                 )
+                .arg(
+                    clap::Arg::new("native_tracing")
+                        .help("Enable profiling from the native stack")
+                        .long("native_tracing")
+                        .required(false),
+                )
                 .arg(arg!(<cmd> ... "command to run").required(false)),
         )
         .subcommand(
@@ -437,6 +446,8 @@ impl Args {
                 };
 
                 let no_drop_root = submatches.occurrences_of("no-drop-root") == 1;
+                let native_tracing = submatches.occurrences_of("native_tracing") == 1;
+
                 let silent = submatches.is_present("silent");
                 let with_subprocesses = submatches.is_present("subprocesses");
                 let nonblocking = submatches.is_present("nonblocking");
@@ -472,6 +483,7 @@ impl Args {
                     flame_min_width,
                     lock_process: !nonblocking,
                     force_version,
+                    native_tracing
                 }
             }
             Some(("report", submatches)) => {
@@ -595,6 +607,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: true,
                     force_version: None,
+                    native_tracing: false
                 },
             }
         );
@@ -619,6 +632,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: true,
                     force_version: None,
+                    native_tracing: false
                 },
             }
         );
@@ -643,6 +657,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: true,
                     force_version: None,
+                    native_tracing: false
                 },
             }
         );
@@ -666,6 +681,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: true,
                     force_version: None,
+                    native_tracing: false
                 },
             }
         );
@@ -690,6 +706,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: true,
                     force_version: None,
+                    native_tracing: false
                 },
             }
         );
@@ -714,6 +731,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: true,
                     force_version: None,
+                    native_tracing: false
                 },
             }
         );
@@ -738,6 +756,7 @@ mod tests {
                     flame_min_width: 0.02,
                     lock_process: true,
                     force_version: None,
+                    native_tracing: false
                 },
             }
         );
@@ -762,6 +781,7 @@ mod tests {
                     flame_min_width: 0.1,
                     lock_process: false,
                     force_version: None,
+                    native_tracing: false
                 },
             }
         );

--- a/src/recorder/record.rs
+++ b/src/recorder/record.rs
@@ -42,7 +42,7 @@ pub struct Config {
     /// This option shouldn't be needed unless you're testing a pre-release Ruby version.
     pub force_version: Option<String>,
     /// Turn on native stack tracing as well
-    pub native_tracing: bool
+    pub native_profiling: bool,
 }
 
 pub struct Recorder {
@@ -64,7 +64,7 @@ impl Recorder {
             config.maybe_duration,
             config.with_subprocesses,
             config.force_version,
-            config.native_tracing
+            config.native_profiling,
         );
 
         Recorder {

--- a/src/recorder/record.rs
+++ b/src/recorder/record.rs
@@ -41,6 +41,8 @@ pub struct Config {
     ///
     /// This option shouldn't be needed unless you're testing a pre-release Ruby version.
     pub force_version: Option<String>,
+    /// Turn on native stack tracing as well
+    pub native_tracing: bool
 }
 
 pub struct Recorder {
@@ -62,6 +64,7 @@ impl Recorder {
             config.maybe_duration,
             config.with_subprocesses,
             config.force_version,
+            config.native_tracing
         );
 
         Recorder {

--- a/src/recorder/snapshot.rs
+++ b/src/recorder/snapshot.rs
@@ -9,5 +9,5 @@ pub fn snapshot(
     lock_process: bool,
     force_version: Option<String>,
 ) -> Result<StackTrace, Error> {
-    RubySpy::retry_new(pid, 10, force_version, true)?.get_stack_trace(lock_process)
+    RubySpy::retry_new(pid, 10, force_version, false)?.get_stack_trace(lock_process)
 }

--- a/src/recorder/snapshot.rs
+++ b/src/recorder/snapshot.rs
@@ -9,5 +9,5 @@ pub fn snapshot(
     lock_process: bool,
     force_version: Option<String>,
 ) -> Result<StackTrace, Error> {
-    RubySpy::retry_new(pid, 10, force_version)?.get_stack_trace(lock_process)
+    RubySpy::retry_new(pid, 10, force_version, false)?.get_stack_trace(lock_process)
 }

--- a/src/recorder/snapshot.rs
+++ b/src/recorder/snapshot.rs
@@ -9,5 +9,5 @@ pub fn snapshot(
     lock_process: bool,
     force_version: Option<String>,
 ) -> Result<StackTrace, Error> {
-    RubySpy::retry_new(pid, 10, force_version, false)?.get_stack_trace(lock_process)
+    RubySpy::retry_new(pid, 10, force_version, true)?.get_stack_trace(lock_process)
 }

--- a/src/sampler/mod.rs
+++ b/src/sampler/mod.rs
@@ -21,6 +21,7 @@ pub struct Sampler {
     total_traces: Arc<AtomicUsize>,
     with_subprocesses: bool,
     force_version: Option<String>,
+    native_tracing: bool
 }
 
 impl Sampler {
@@ -31,6 +32,7 @@ impl Sampler {
         time_limit: Option<Duration>,
         with_subprocesses: bool,
         force_version: Option<String>,
+        native_tracing: bool
     ) -> Self {
         Sampler {
             done: Arc::new(AtomicBool::new(false)),
@@ -42,6 +44,7 @@ impl Sampler {
             total_traces: Arc::new(AtomicUsize::new(0)),
             with_subprocesses,
             force_version,
+            native_tracing
         }
     }
 
@@ -72,6 +75,7 @@ impl Sampler {
         let result_sender = result_sender.clone();
         let timing_error_traces = self.timing_error_traces.clone();
         let total_traces = self.total_traces.clone();
+        let native_tracing = self.native_tracing;
 
         if self.with_subprocesses {
             // Start a thread which watches for new descendents and starts new recorders when they
@@ -116,6 +120,7 @@ impl Sampler {
                                 trace_sender_clone,
                                 lock_process,
                                 force_version,
+                                native_tracing
                             );
                             result_sender.send(result).expect("couldn't send error");
                             drop(result_sender);
@@ -145,6 +150,7 @@ impl Sampler {
                     trace_sender,
                     lock_process,
                     force_version,
+                    native_tracing
                 );
                 result_sender.send(result).unwrap();
                 drop(result_sender);
@@ -170,9 +176,10 @@ fn sample(
     sender: SyncSender<StackTrace>,
     lock_process: bool,
     force_version: Option<String>,
+    native_tracing: bool,
 ) -> Result<(), Error> {
     let mut process =
-        crate::core::ruby_spy::RubySpy::retry_new(pid, 10, force_version).context("new spy")?;
+        crate::core::ruby_spy::RubySpy::retry_new(pid, 10, force_version, native_tracing).context("new spy")?;
 
     let mut total = 0;
     let mut errors = 0;
@@ -309,7 +316,7 @@ mod tests {
         let mut process = RubyScript::new("ci/ruby-programs/infinite.rb");
         let pid = process.id() as Pid;
 
-        let sampler = Sampler::new(pid, 100, true, None, false, None);
+        let sampler = Sampler::new(pid, 100, true, None, false, None, false);
         let (trace_sender, trace_receiver) = std::sync::mpsc::sync_channel(100);
         let (result_sender, result_receiver) = std::sync::mpsc::channel();
         sampler
@@ -343,6 +350,7 @@ mod tests {
             Some(std::time::Duration::from_millis(500)),
             false,
             None,
+            false
         );
         let (trace_sender, trace_receiver) = std::sync::mpsc::sync_channel(100);
         let (result_sender, result_receiver) = std::sync::mpsc::channel();
@@ -399,7 +407,7 @@ mod tests {
             .unwrap();
         let pid = process.id() as Pid;
 
-        let sampler = Sampler::new(pid, 5, true, None, true, None);
+        let sampler = Sampler::new(pid, 5, true, None, true, None, false);
         let (trace_sender, trace_receiver) = std::sync::mpsc::sync_channel(100);
         let (result_sender, result_receiver) = std::sync::mpsc::channel();
         sampler


### PR DESCRIPTION
resolves https://github.com/rbspy/rbspy/issues/372

# How does it work? 

When the `native-profiling` flag is on and we are on linux or windows (remoteprocess only supports unwinding on these 2 platforms afaik) then, after getting the ruby trace, we: 

- get native stack frames using remoteprocess
- go through the ruby frames, when a c function is found
  - find the closest start of a c function invocation in the native frames
  - add all the frames from it
  - stop adding when we know we are going back to ruby

The start of a c function is: `rb_vm_exec` and the end of it is: `vm_call_cfunc_with_frame`.

By interweaving native and ruby frames this way, we get to profile both ruby and native code! 