### PR TITLE
Use Dependabot to maintain dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Would you like to use Dependabot? 
- Dependabot maintains dependencies: it does so by raising a PR to update to a new version
- github native, free and easy to use
- [more about Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates)

In this PR I've configured Dependabot to check cargo and github-actions for updates weekly - this can be adapted very easily!
