### PR TITLE
Calculate checksums for the binary artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,13 @@ jobs:
             fi
           done
 
+      - name: Calculate checksums
+        run: |
+          set -euo pipefail
+
+          cd archives
+          sha256sum * > checksums.txt
+
       - uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.1.1
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This pull request adds `checksums.txt` file with SHA256 checksums of all binary archives to be published on GitHub Releases page. This allows users of the tool to verify the checksum unarchiving and installing the binary, preventing some of the supply chain attacks.

The GitHub release will look like this:

![CleanShot 2025-04-23 at 17 58 18@2x](https://github.com/user-attachments/assets/c6d7d052-a678-4f28-83ec-f42f7114a7e8)

An example of the `checksums.txt` file:

```txt
c18cf49e7dd26f888f6f7f7b4f708d81eb19b098a6b26a24b227f1f871f424ec  rbspy-aarch64-unknown-linux-gnu.tar.gz
d06bd08bd20da2b30c8bc3bf24c60d6707f2f085b9c1724c336c9bf75c04463b  rbspy-aarch64-unknown-linux-musl.tar.gz
bec897233bfc4b4d8ea17ad9dc07b4527313fb3312103dab0813781323b3d1cb  rbspy-x86_64-apple-darwin.tar.gz
bc14f30b5ae97a36b6c4f5a4b8cd86270256ec2bb7b47b18cef4b5768d86431c  rbspy-x86_64-pc-windows-msvc.exe.zip
0e706ca985c4ed51b4833cb1ebc026e27f3ec01eb4f0cf5200b4018737e3f501  rbspy-x86_64-unknown-freebsd.tar.gz
b94b3882602cbf6bee81a143df5f2e8c7100717ed0bb0975ec1566e4c2775b72  rbspy-x86_64-unknown-linux-gnu.tar.gz
5fff7555ff575c1d3c4cca4f171f564f59f725fdcc170929ff37505874da3974  rbspy-x86_64-unknown-linux-musl.tar.gz
```