### PR TITLE
Switch string limit check for a sanity check of 1 million bytes

### DIFF
--- a/src/core/ruby_version.rs
+++ b/src/core/ruby_version.rs
@@ -292,7 +292,7 @@ macro_rules! ruby_version_v3_3_x(
             get_stack_trace!(rb_execution_context_struct);
             get_execution_context_from_vm!();
             get_ruby_string_3_3_0!();
-            get_ruby_string_array_3_3_0!();
+            get_ruby_string_array_3_2_0!();
             get_cfps!();
             get_pos!(rb_iseq_constant_body);
             get_lineno_2_6_0!();
@@ -676,88 +676,6 @@ macro_rules! get_ruby_string_array_3_2_0(
     )
 );
 
-macro_rules! get_ruby_string_array_3_3_0(
-    () => (
-        fn get_ruby_string_limit<T>(
-            addr: usize,
-            max: usize,
-            source: &T
-        ) -> Result<String> where T: ProcessMemory {
-            let rstring: RString = source.copy_struct(addr).context("couldn't copy rstring")?;
-            // See RSTRING_NOEMBED and RUBY_FL_USER1
-            let is_embedded_string = rstring.basic.flags & 1 << 13 == 0;
-            if is_embedded_string {
-                // Workaround for Windows strings until we have OS-specific bindings
-                #[cfg(target_os = "windows")]
-                let addr = addr + 4;
-
-                if (rstring.len as usize) > max {
-                    return Err(anyhow::anyhow!("string length {} exceeds maximum {}", rstring.len, max));
-                }
-                // The introduction of Variable Width Allocation (VWA) for strings means that
-                // the length of embedded strings varies at runtime. Instead of assuming a
-                // constant length, we need to read the length from the struct.
-                //
-                // See https://bugs.ruby-lang.org/issues/18239
-                let embedded_str_bytes = source.copy(
-                    addr + std::mem::size_of::<RBasic>() + std::mem::size_of::<std::os::raw::c_long>(),
-                    rstring.len as usize
-                ).context("couldn't copy rstring")?;
-                return String::from_utf8(embedded_str_bytes).context("couldn't convert ruby string bytes to string")
-            } else {
-                unsafe {
-                    let addr = rstring.as_.heap.ptr as usize;
-                    let len = rstring.len as usize;
-                    let heap_str_bytes = source.copy(addr as usize, len).context("couldn't copy ruby string from heap")?;
-                    return String::from_utf8(heap_str_bytes).context("couldn't convert ruby string bytes to string");
-                }
-            }
-        }
-
-
-        // Returns (path, absolute_path)
-        fn get_ruby_string_array<T>(addr: usize, string_class: usize, source: &T) -> Result<(String, String)> where T: ProcessMemory {
-            let rstring: RString = source.copy_struct(addr).context("couldn't copy RString")?;
-            if rstring.basic.klass as usize == string_class {
-                let s = get_ruby_string(addr, source)?;
-                return Ok((s.clone(), s))
-            }
-
-            // Due to VWA in ruby 3.2, we can't get the exact length of the RArray. So,
-            // we use these inline structs and assume that there are at least two array
-            // elements when we're reading a pathobj.
-            #[repr(C)]
-            #[derive(Copy, Clone)]
-            struct PaddedRArray {
-                pub basic: RBasic,
-                pub as_: PaddedRArray__bindgen_ty_1,
-            }
-            #[repr(C)]
-            #[derive(Copy, Clone)]
-            union PaddedRArray__bindgen_ty_1 {
-                pub heap: RArray__bindgen_ty_1__bindgen_ty_1,
-                pub ary: [VALUE; 2usize],
-            }
-
-            // otherwise it's an RArray
-            let rarray: PaddedRArray = source.copy_struct(addr).context("couldn't copy RArray")?;
-            // TODO: this assumes that the array contents are stored inline and not on the heap
-            // I think this will always be true but we should check instead
-            // the reason I am not checking is that I don't know how to check yet
-            let path_addr: usize = unsafe { rarray.as_.ary[0] as usize }; // 0 => relative path
-            let abs_path_addr: usize = unsafe { rarray.as_.ary[1] as usize }; // 1 => absolute path
-
-            let rel_path = get_ruby_string(path_addr, source)?;
-            // In the case of internal ruby functions (and maybe others), we may not get a valid
-            // pointer here
-            let abs_path = get_ruby_string_limit(abs_path_addr, 4096, source)
-                .unwrap_or(String::from("unknown"));
-
-            Ok((rel_path, abs_path))
-        }
-    )
-);
-
 macro_rules! rstring_as_array_1_9_1(
     () => (
         unsafe fn rstring_as_array(rstring: RString) -> [::std::os::raw::c_char; 24usize] {
@@ -845,6 +763,9 @@ macro_rules! get_ruby_string_3_3_0(
             source: &T
         ) -> Result<String> where T: ProcessMemory {
             let rstring: RString = source.copy_struct(addr).context("couldn't copy rstring")?;
+            if rstring.len > 1_000_000 {
+                return Err(anyhow::anyhow!("string length {} for string at {:X} appears invalid", rstring.len, addr));
+            }
             // See RSTRING_NOEMBED and RUBY_FL_USER1
             let is_embedded_string = rstring.basic.flags & 1 << 13 == 0;
             if is_embedded_string {


### PR DESCRIPTION
Proposed fix for #401 this:

The root cause seems to be that we read invalid memory, and `rstring.len` doesn't contain a string length, but rather, a memory address. That memory address is absurdly large, and we fail to alloc while trying to read it.

To fix this, i'm:

- Removes the `_limit` variant I added and adding a hardcoded check of 1 million bytes directly to `get_ruby_string_3_3_0`
- Removes the ruby string array read that I added which uses this limit variant

I suspect the issue is that we are encountering a ruby with different field offsets or sizes than what we were compiled when we ran bindgen, or we are passing it an invalid address. I'm adding the address to the error so we can see if there is any obvious pattern to them (eg, maybe some are VALUE of 0x0f, which is Qnil)